### PR TITLE
Add ability to use other mounters for unit testing

### DIFF
--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -19,6 +19,7 @@ package nfs
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/util/mount"
 )
 
 type nfsDriver struct {
@@ -61,14 +62,15 @@ func NewNFSdriver(nodeID, endpoint string) *nfsDriver {
 	return n
 }
 
-func NewNodeServer(n *nfsDriver) *nodeServer {
+func NewNodeServer(n *nfsDriver, mounter mount.Interface) *nodeServer {
 	return &nodeServer{
-		Driver: n,
+		Driver:  n,
+		mounter: mounter,
 	}
 }
 
 func (n *nfsDriver) Run() {
-	n.ns = NewNodeServer(n)
+	n.ns = NewNodeServer(n, mount.New(""))
 	s := NewNonBlockingGRPCServer()
 	s.Start(n.endpoint,
 		NewDefaultIdentityServer(n),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Allow other mounters to be used so that we can add unit tests using FakeMounter.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
