### PR TITLE
Rename driver to follow CSI plugin naming conventions

### DIFF
--- a/deploy/kubernetes/csi-nfs-driverinfo.yaml
+++ b/deploy/kubernetes/csi-nfs-driverinfo.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
-  name: csi-nfsplugin
+  name: nfs.csi.k8s.io
 spec:
   attachRequired: false
   volumeLifecycleModes:

--- a/examples/kubernetes/nginx.yaml
+++ b/examples/kubernetes/nginx.yaml
@@ -10,7 +10,7 @@ spec:
   capacity:
     storage: 100Gi
   csi:
-    driver: csi-nfsplugin
+    driver: nfs.csi.k8s.io
     volumeHandle: data-id
     volumeAttributes: 
       server: 127.0.0.1

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -36,7 +36,7 @@ type nfsDriver struct {
 }
 
 const (
-	driverName = "csi-nfsplugin"
+	driverName = "nfs.csi.k8s.io"
 )
 
 var (

--- a/test/nfs-testdriver.go
+++ b/test/nfs-testdriver.go
@@ -54,7 +54,7 @@ func initNFSDriver(name string, manifests ...string) testsuites.TestDriver {
 
 func InitNFSDriver() testsuites.TestDriver {
 
-	return initNFSDriver("csi-nfsplugin",
+	return initNFSDriver("nfs.csi.k8s.io",
 		"csi-attacher-nfsplugin.yaml",
 		"csi-attacher-rbac.yaml",
 		"csi-nodeplugin-nfsplugin.yaml",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Changes name of the driver to follow dotted conventions established in other CSI drivers.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/csi-driver-nfs/issues/19

**Does this PR introduce a user-facing change?**:
```release-note
Changing name of the driver from "csi-nfsplugin" to "nfs.csi.k8s.io"
```
