### PR TITLE
Change base image to centos:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM centos:7.4.1708
+FROM centos:latest
 
 # Copy nfsplugin from build _output directory
 COPY bin/nfsplugin /nfsplugin
 
-RUN yum -y install nfs-utils && yum -y install epel-release && yum -y install jq && yum clean all
+RUN yum -y install nfs-utils epel-release jq && yum clean all
 
 ENTRYPOINT ["/nfsplugin"]


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updating the container image base to contain fewer vulnerabilities (drops from [71](https://quay.io/repository/k8scsi/nfsplugin?tag=latest&tab=tags) to [5](https://quay.io/repository/wozniakjan/nfsplugin/manifest/sha256:b4079ac1591274d831a5bb6e6418aa7a6767ae930bd4f19e7a9df0ed6ed2f52e?tab=vulnerabilities)). Also proposes to use `latest` tag as there is not really much that we use from the base image and I think it is rather unlikely to break the go binary anyways.

This changes the base from centos7 (latest 7 tag contains 7 vulnerabilities) to current centos8 (latest 8 tag contains 5 vulnerabilities). The last 5 critical vulnerabilities do not have released fixes in centos image yet and uninstalling systemd is protected on RH based distros.
https://quay.io/repository/wozniakjan/nfsplugin?tab=tags

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/csi-driver-nfs/issues/25

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
