### PR TITLE
Remove hostnetwork from plugin

### DIFF
--- a/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
+++ b/deploy/kubernetes/csi-nodeplugin-nfsplugin.yaml
@@ -14,7 +14,6 @@ spec:
         app: csi-nodeplugin-nfsplugin
     spec:
       serviceAccount: csi-nodeplugin
-      hostNetwork: true
       containers:
         - name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2

--- a/examples/kubernetes/nginx.yaml
+++ b/examples/kubernetes/nginx.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     name: data-nfsplugin
 spec:
+  claimRef:
+    name: data-nfsplugin
+    namespace: default
   accessModes:
   - ReadWriteMany
   capacity:
@@ -12,7 +15,9 @@ spec:
   csi:
     driver: nfs.csi.k8s.io
     volumeHandle: data-id
-    volumeAttributes: 
+    volumeAttributes:
+      # The nfs server could be a K8s service
+      # server: nfs-server.default.svc.cluster.local
       server: 127.0.0.1
       share: /export
 ---
@@ -26,28 +31,22 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  selector:
-    matchExpressions:
-    - key: name
-      operator: In
-      values: ["data-nfsplugin"]
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: nginx 
+  name: nginx
 spec:
   containers:
   - image: maersk/nginx
-    imagePullPolicy: Always
     name: nginx
     ports:
     - containerPort: 80
       protocol: TCP
     volumeMounts:
       - mountPath: /var/www
-        name: data-nfsplugin 
+        name: data-nfsplugin
   volumes:
   - name: data-nfsplugin
     persistentVolumeClaim:
-      claimName: data-nfsplugin 
+      claimName: data-nfsplugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove hostnetwork from the driver Daemonset so that the csi driver can resolve K8s dns names.

Also clean up the example to use claimRef instead of a selector which is not as exact in matching.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes issue where the driver could not mount a nfs server via Kubernetes dns service name.
```
