### PR TITLE
test: add sanity test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,8 @@ CMDS=nfsplugin
 all: build
 
 include release-tools/build.make
+
+.PHONY: sanity-test
+sanity-test: build
+	./test/sanity/run-test.sh
+

--- a/test/sanity/README.md
+++ b/test/sanity/README.md
@@ -1,0 +1,8 @@
+## Sanity Tests
+Testing the NFS CSI driver using the [`sanity`](https://github.com/kubernetes-csi/csi-test/tree/master/pkg/sanity) package test suite.
+
+### Run sanity tests
+```
+make sanity-test
+```
+

--- a/test/sanity/run-test.sh
+++ b/test/sanity/run-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function cleanup {
+  echo 'pkill -f nfsplugin'
+  pkill -f nfsplugin
+  echo 'Deleting CSI sanity test binary'
+  rm -rf csi-test
+}
+trap cleanup EXIT
+
+function install_csi_sanity_bin {
+  echo 'Installing CSI sanity test binary...'
+  git clone https://github.com/kubernetes-csi/csi-test.git -b v2.2.0
+  pushd csi-test/cmd/csi-sanity
+  make
+  popd
+}
+
+install_csi_sanity_bin
+
+readonly endpoint='unix:///tmp/csi.sock'
+nodeid='CSINode'
+if [[ "$#" -gt 0 ]] && [[ -n "$1" ]]; then
+  nodeid="$1"
+fi
+
+bin/nfsplugin --endpoint "$endpoint" --nodeid "$nodeid" -v=5 &
+
+echo 'Begin to run sanity test...'
+readonly CSI_SANITY_BIN='csi-test/cmd/csi-sanity/csi-sanity'
+"$CSI_SANITY_BIN" --ginkgo.v --ginkgo.noColor --csi.endpoint="$endpoint"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
test: add sanity test

Also need to fix the sanity test failure
```
# make sanity-test
[Fail] Node Service [BeforeEach] NodePublishVolume should fail when no volume id is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodePublishVolume should fail when no target path is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodePublishVolume should fail when no volume capability is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeUnpublishVolume should fail when no volume id is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeUnpublishVolume should fail when no target path is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeStageVolume should fail when no volume id is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeStageVolume should fail when no staging target path is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeStageVolume should fail when no volume capability is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeUnstageVolume should fail when no volume id is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeUnstageVolume should fail when no staging target path is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeGetVolumeStats should fail when no volume id is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeGetVolumeStats should fail when no volume path is provided
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeGetVolumeStats should fail when volume is not found
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

[Fail] Node Service [BeforeEach] NodeGetVolumeStats should fail when volume does not exist on the specified path
/root/go/pkg/mod/github.com/kubernetes-csi/csi-test@v2.2.0+incompatible/pkg/sanity/sanity.go:234

Ran 64 of 72 Specs in 0.035 seconds
FAIL! -- 0 Passed | 64 Failed | 0 Pending | 8 Skipped
--- FAIL: TestSanity (0.05s)

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
test: add sanity test
```
