### PR TITLE
fix: update livenessprobe version from v1.1.0 to v2.0.0

### DIFF
--- a/charts/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/charts/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -50,7 +50,7 @@ spec:
           image: "{{ .Values.image.livenessProbe.repository }}:{{ .Values.image.livenessProbe.tag }}"
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29642
             - --v=5
           imagePullPolicy: {{ .Values.image.livenessProbe.pullPolicy }}

--- a/charts/csi-driver-nfs/values.yaml
+++ b/charts/csi-driver-nfs/values.yaml
@@ -9,7 +9,7 @@ image:
         pullPolicy: ifNotPresent
     livenessProbe:
         repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
-        tag: v1.1.0
+        tag: v2.0.0
         pullPolicy: ifNotPresent
     nodeDriverRegistrar:
         repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar

--- a/deploy/kubernetes/csi-nfs-controller.yaml
+++ b/deploy/kubernetes/csi-nfs-controller.yaml
@@ -45,10 +45,10 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v1.1.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.0.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
+            - --probe-timeout=3s
             - --health-port=29642
             - --v=5
           volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Replace livenessprobe flag --connection-timeout with --probe-timeout.
Update the livenessprobe version from v1.1.0 to v2.0.0.
Update helm charts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
