### PR TITLE
fix: makeDir error in CreateVolume

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -100,7 +100,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// Create subdirectory under base-dir
 	// TODO: revisit permissions
 	internalVolumePath := cs.getInternalVolumePath(nfsVol)
-	if err = os.Mkdir(internalVolumePath, 0777); err != nil {
+	if err = os.Mkdir(internalVolumePath, 0777); err != nil && !os.IsExist(err) {
 		return nil, status.Errorf(codes.Internal, "failed to make subdirectory: %v", err.Error())
 	}
 	// Remove capacity setting when provisioner 1.4.0 is available with fix for


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixed following issue:
```
E0209 23:34:10.378470       1 utils.go:89] GRPC error: rpc error: code = Internal desc = failed to make subdirectory: mkdir /tmp/pvc-5abc9306-717c-4fba-afe5-7fcdf0439822/pvc-5abc9306-717c-4fba-afe5-7fcdf0439822: file exists
 
it's strange because I login to the master node where the controller is running on, and I don't find /tmp/pvc-5abc9306-717c-4fba-afe5-7fcdf0439822/pvc-5abc9306-717c-4fba-afe5-7fcdf0439822 is there
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: makeDir error in CreateVolume
```
