### PR TITLE
fix: change base image to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:latest
+FROM k8s.gcr.io/build-image/debian-base-amd64:v2.1.3
 
 # Copy nfsplugin from build _output directory
 COPY bin/nfsplugin /nfsplugin
 
-RUN yum -y install nfs-utils epel-release jq && yum clean all
+# this is a workaround to install nfs-common & nfs-kernel-server and don't quit with error
+# https://github.com/kubernetes-sigs/blob-csi-driver/issues/214#issuecomment-781602430
+RUN apt update && apt install ca-certificates mount nfs-common nfs-kernel-server -y || true
 
 ENTRYPOINT ["/nfsplugin"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
chore: change base image to debian

same as https://github.com/kubernetes-csi/csi-driver-smb/blob/a6fcf70cf8bf8ca1673147bcc9b7f7ceef29386f/pkg/smbplugin/Dockerfile#L18

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
original base image error:
```
nfs image building error:
#3 [internal] load metadata for docker.io/library/centos:latest
#3 ERROR: no match for platform in manifest sha256:5528e8b1b1719d34604c87e11dcd1c0a20bedf46e83b5632cdeac91b8c04efc1: not found
```
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-csi-driver-nfs-push-images/1362034346201976832

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
chore: change base image to debian
```
