### PR TITLE
Allow shares that are not at the root

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -359,15 +360,16 @@ func (cs *ControllerServer) getVolumeIDFromNfsVol(vol *nfsVolume) string {
 
 // Given a CSI volume id, return a nfsVolume
 func (cs *ControllerServer) getNfsVolFromID(id string) (*nfsVolume, error) {
-	tokens := strings.Split(id, "/")
-	if len(tokens) != totalIDElements {
-		return nil, fmt.Errorf("volume id %q unexpected format: got %v token(s) instead of %v", id, len(tokens), totalIDElements)
+	volRegex := regexp.MustCompile("^([^/]+)/(.*)/([^/]+)$")
+	tokens := volRegex.FindStringSubmatch(id)
+	if tokens == nil {
+		return nil, fmt.Errorf("Could not split %q into server, baseDir and subDir", id)
 	}
 
 	return &nfsVolume{
 		id:      id,
-		server:  tokens[idServer],
-		baseDir: tokens[idBaseDir],
-		subDir:  tokens[idSubDir],
+		server:  tokens[1],
+		baseDir: tokens[2],
+		subDir:  tokens[3],
 	}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the split in getNfsVolFromID expects that the share is just one folder like /data and not something like /data/kubernetes and fails in the later case with an unexpected amount of tokens.

This splits the id into server until the first / and subdir starting from the last / character. Everything between them is considered a part of baseDir

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #184

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
