### PR TITLE
Add K8s external storage E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,8 @@ e2e-teardown:
 
 .PHONY: e2e-test
 e2e-test:
-	go test -v -timeout=0 ./test/e2e ${GINKGO_FLAGS}
+	if [ ! -z "$(EXTERNAL_E2E_TEST)" ]; then \
+		bash ./test/external-e2e/run.sh;\
+	else \
+		go test -v -timeout=0 ./test/e2e ${GINKGO_FLAGS};\
+	fi

--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xe
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+
+install_ginkgo () {
+    apt update -y
+    apt install -y golang-ginkgo-dev
+}
+
+setup_e2e_binaries() {
+    # download k8s external e2e binary for kubernetes v1.19
+    curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.19.0/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
+    tar -xvf e2e-tests.tar.gz && rm e2e-tests.tar.gz
+
+    # install the csi driver nfs
+    mkdir -p /tmp/csi-nfs && cp deploy/example/storageclass-nfs.yaml /tmp/csi-nfs/storageclass.yaml
+    make e2e-bootstrap
+    make install-nfs-server
+}
+
+print_logs() {
+    echo "print out driver logs ..."
+    bash ./test/utils/nfs_log.sh
+}
+
+install_ginkgo
+setup_e2e_binaries
+trap print_logs EXIT
+
+ginkgo -p --progress --v -focus='External.Storage.*nfs.csi.k8s.io' \
+       -skip='\[Disruptive\]|\[Slow\]' kubernetes/test/bin/e2e.test  -- \
+       -storage.testdriver=$PROJECT_ROOT/test/external-e2e/testdriver.yaml \
+       --kubeconfig=$KUBECONFIG

--- a/test/external-e2e/testdriver.yaml
+++ b/test/external-e2e/testdriver.yaml
@@ -1,0 +1,12 @@
+# Manifest for Kubernetes external tests.
+# See https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+
+StorageClass:
+  FromFile: /tmp/csi-nfs/storageclass.yaml
+DriverInfo:
+  Name: nfs.csi.k8s.io
+  Capabilities:
+    persistence: true
+    exec: true
+    multipods: true
+    RWX: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind flake

**What this PR does / why we need it**:
Adding External e2e tests. Offers a better way to test the driver changes. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
