### PR TITLE
chore: upgrade base image to fix CVE issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG ARCH=amd64
 
-FROM k8s.gcr.io/build-image/debian-base-${ARCH}:v2.1.3
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.6.0
 
 # Copy nfsplugin from build _output directory
 COPY bin/nfsplugin /nfsplugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
chore: upgrade base image to fix CVE issue

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
# trivy --ignore-unfixed mcr.microsoft.com/k8s/csi/nfs-csi:latest
2021-05-12T10:41:52.693Z        INFO    Detecting Debian vulnerabilities...
2021-05-12T10:41:52.725Z        INFO    Detecting gobinary vulnerabilities...

mcr.microsoft.com/k8s/csi/nfs-csi:latest (debian 10.5)
======================================================
Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 2, CRITICAL: 0)

+---------------+------------------+----------+-------------------+----------------------+---------------------------------------+
|    LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |    FIXED VERSION     |                 TITLE                 |
+---------------+------------------+----------+-------------------+----------------------+---------------------------------------+
| apt           | CVE-2020-27350   | MEDIUM   | 1.8.2.1           | 1.8.2.2              | apt: integer overflows and underflows |
|               |                  |          |                   |                      | while parsing .deb packages           |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2020-27350 |
+---------------+                  +          +                   +                      +                                       +
| libapt-pkg5.0 |                  |          |                   |                      |                                       |
|               |                  |          |                   |                      |                                       |
|               |                  |          |                   |                      |                                       |
+---------------+------------------+----------+-------------------+----------------------+---------------------------------------+
| libp11-kit0   | CVE-2020-29361   | HIGH     | 0.23.15-2         | 0.23.15-2+deb10u1    | p11-kit: integer overflow when        |
|               |                  |          |                   |                      | allocating memory for arrays          |
|               |                  |          |                   |                      | or attributes and object...           |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2020-29361 |
+               +------------------+          +                   +                      +---------------------------------------+
|               | CVE-2020-29363   |          |                   |                      | p11-kit: out-of-bounds write in       |
|               |                  |          |                   |                      | p11_rpc_buffer_get_byte_array_value   |
|               |                  |          |                   |                      | function in rpc-message.c             |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2020-29363 |
+               +------------------+----------+                   +                      +---------------------------------------+
|               | CVE-2020-29362   | MEDIUM   |                   |                      | p11-kit: out-of-bounds read in        |
|               |                  |          |                   |                      | p11_rpc_buffer_get_byte_array         |
|               |                  |          |                   |                      | function in rpc-message.c             |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2020-29362 |
+---------------+------------------+          +-------------------+----------------------+---------------------------------------+
| libzstd1      | CVE-2021-24031   |          | 1.3.8+dfsg-3      | 1.3.8+dfsg-3+deb10u1 | zstd: adds read permissions           |
|               |                  |          |                   |                      | to files while being                  |
|               |                  |          |                   |                      | compressed or uncompressed            |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2021-24031 |
+               +------------------+          +                   +----------------------+---------------------------------------+
|               | CVE-2021-24032   |          |                   | 1.3.8+dfsg-3+deb10u2 | zstd: Race condition                  |
|               |                  |          |                   |                      | allows attacker to access             |
|               |                  |          |                   |                      | world-readable destination file       |
|               |                  |          |                   |                      | -->avd.aquasec.com/nvd/cve-2021-24032 |
+---------------+------------------+----------+-------------------+----------------------+---------------------------------------+

nfsplugin
=========
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+------------------+------------------+----------+-------------------+-----------------------+---------------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |     FIXED VERSION     |                 TITLE                 |
+------------------+------------------+----------+-------------------+-----------------------+---------------------------------------+
| k8s.io/client-go | CVE-2019-11250   | MEDIUM   | v0.20.0           | 1.15.4, 1.16.1-beta.0 | kubernetes: Bearer tokens             |
|                  |                  |          |                   |                       | written to logs at high               |
|                  |                  |          |                   |                       | verbosity levels (>= 7)...            |
|                  |                  |          |                   |                       | -->avd.aquasec.com/nvd/cve-2019-11250 |
+------------------+------------------+----------+-------------------+-----------------------+---------------------------------------+
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
chore: upgrade base image to fix CVE issue
```
