### PR TITLE
Add usage using hack/verify-examples.sh

### DIFF
--- a/deploy/example/README.md
+++ b/deploy/example/README.md
@@ -13,7 +13,7 @@ Please refer to [driver parameters](../../docs/driver-parameters.md) for more de
 
 ## Storage Class Usage (Dynamic Provisioning)
 
-- Follow the folling command to create a `StorageClass`, and then `PersistentVolume` and `PersistentVolumeClaim` dynamically.
+- Follow the following command to create a `StorageClass`, and then `PersistentVolume` and `PersistentVolumeClaim` dynamically.
 
 ```bash
 # create StorageClass
@@ -25,7 +25,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nf
 
 ## PV/PVC Usage (Static Provisioning)
 
-- Follow the folling command to create `PersistentVolume` and `PersistentVolumeClaim` statically.
+- Follow the following command to create `PersistentVolume` and `PersistentVolumeClaim` statically.
 
 ```bash
 # create PV
@@ -33,4 +33,15 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nf
 
 # create PVC
 kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/pvc-nfs-csi-static.yaml
+```
+
+## Deployment/Statefulset Usage
+
+- Follow the following command to create `Deployment` and `Statefulset` .
+
+```bash
+# create Deployment and Statefulset
+git clone https://github.com/kubernetes-csi/csi-driver-nfs.git
+cd csi-driver-nfs
+./hack/verify-examples.sh
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:

deploy/example/README.md includes `storage` / `PV` / `PVC` usage  . But we can not deploy any pod/deployment/statefulset even if following to this README, so we cannot check NFS CSI driver using simple nginx sample.
This PR adds `deployment` / `statefulset` usage using hack/verify-examples.sh to README.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
