### PR TITLE
images: use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Migrating gcb-docker-gcloud to to community-owned infrastructure

**Which issue(s) this PR fixes**:
Fixes # [Migrate away from google.com gcp project k8s-testimages kubernetes/k8s.io#1523](https://github.com/kubernetes/k8s.io/issues/1523)

**Special notes for your reviewer**:
 Related:
* Followup to: [images: add/update READMEs to trigger image builds kubernetes/test-infra#23656](https://github.com/kubernetes/test-infra/pull/23656)


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
