### PR TITLE
Reset directory permissions

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -104,6 +104,10 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if err = os.Mkdir(internalVolumePath, 0777); err != nil && !os.IsExist(err) {
 		return nil, status.Errorf(codes.Internal, "failed to make subdirectory: %v", err.Error())
 	}
+	// Reset directory permissions because of umask problems
+	if err = os.Chmod(internalVolumePath, 0777); err != nil {
+		klog.Warningf("failed to chmod subdirectory: %v", err.Error())
+	}
 	return &csi.CreateVolumeResponse{Volume: cs.nfsVolToCSI(nfsVol)}, nil
 }
 


### PR DESCRIPTION
### Reset directory permissions

- The permission of the storage volume created by os.mkdir(vol,0777) is 755 because of umask
- A POD created in the following way has no write permission
- The user in the container is not root
```
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: statefulset-nfs
  labels:
    app: nginx
spec:
  serviceName: statefulset-nfs
  replicas: 1
  template:
    metadata:
      labels:
        app: nginx
    spec:
      securityContext:
        runAsUser: 1000
        runAsGroup: 3000
        fsGroup: 2000
      nodeSelector:
        "kubernetes.io/os": linux
      containers:
        - name: statefulset-nfs
          image: mcr.microsoft.com/oss/nginx/nginx:1.19.5
          command:
            - "/bin/bash"
            - "-c"
            - set -euo pipefail; while true; do echo $(date) >> /mnt/nfs/outfile; sleep 1; done
          volumeMounts:
            - name: persistent-storage
              mountPath: /mnt/nfs
  updateStrategy:
    type: RollingUpdate
  selector:
    matchLabels:
      app: nginx
  volumeClaimTemplates:
    - metadata:
        name: persistent-storage
        annotations:
          volume.beta.kubernetes.io/storage-class: nfs-csi
      spec:
        accessModes: ["ReadWriteOnce"]
        resources:
          requests:
            storage: 10Gi
```
- This update resets the permissions of the directory after it is created
```release-note
Fix directory permissions problems caused by umask
```