### PR TITLE
fix: armv7 docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ARCH=amd64
-
 FROM k8s.gcr.io/build-image/debian-base:buster-v1.6.0
+
+# Architecture for bin folder
+ARG ARCH
 
 # Copy nfsplugin from build _output directory
 COPY bin/${ARCH}/nfsplugin /nfsplugin

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ nfs:
 
 .PHONY: nfs-armv7
 nfs-armv7:
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -a -ldflags "${LDFLAGS} ${EXT_LDFLAGS}" -mod vendor -o bin/arm/v7/nfsplugin ./cmd/nfsplugin
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -ldflags "${LDFLAGS} ${EXT_LDFLAGS}" -mod vendor -o bin/arm/v7/nfsplugin ./cmd/nfsplugin
 
 .PHONY: container-build
 container-build:


### PR DESCRIPTION
Moves the ARCH build argument after the first FROM so it has the proper
value.
(https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact)

Adds the GOARM=7 option to the armv7 GO build.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #239 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
