### PR TITLE
fix: driver version print in logging

### DIFF
--- a/cmd/nfsplugin/main.go
+++ b/cmd/nfsplugin/main.go
@@ -62,6 +62,6 @@ func handle() {
 		parsedPerm = &permu32
 	}
 
-	d := nfs.NewNFSdriver(*nodeID, *driverName, *endpoint, parsedPerm)
+	d := nfs.NewDriver(*nodeID, *driverName, *endpoint, parsedPerm)
 	d.Run(false)
 }

--- a/hack/release-image.sh
+++ b/hack/release-image.sh
@@ -28,7 +28,7 @@ export IMAGENAME=public/k8s/csi/nfs-csi
 export CI=1
 export PUBLISH=1
 az acr login --name $REGISTRY_NAME
-make container push push-latest
+make && make container push push-latest
 
 echo "sleep 60s ..."
 sleep 60

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -49,7 +49,7 @@ var (
 func initTestController(t *testing.T) *ControllerServer {
 	var perm *uint32
 	mounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{}}
-	driver := NewNFSdriver("", "", "", perm)
+	driver := NewDriver("", "", "", perm)
 	driver.ns = NewNodeServer(driver, mounter)
 	cs := NewControllerServer(driver)
 	cs.workingMountDir = "/tmp"

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -52,16 +52,12 @@ const (
 	paramShare = "share"
 )
 
-var (
-	version = "3.0.0"
-)
-
-func NewNFSdriver(nodeID, driverName, endpoint string, perm *uint32) *Driver {
-	klog.Infof("Driver: %v version: %v", driverName, version)
+func NewDriver(nodeID, driverName, endpoint string, perm *uint32) *Driver {
+	klog.V(2).Infof("Driver: %v version: %v", driverName, driverVersion)
 
 	n := &Driver{
 		name:     driverName,
-		version:  version,
+		version:  driverVersion,
 		nodeID:   nodeID,
 		endpoint: endpoint,
 		cap:      map[csi.VolumeCapability_AccessMode_Mode]bool{},
@@ -79,9 +75,6 @@ func NewNFSdriver(nodeID, driverName, endpoint string, perm *uint32) *Driver {
 	}
 	n.AddVolumeCapabilityAccessModes(vcam)
 
-	// NFS plugin does not support ControllerServiceCapability now.
-	// If support is added, it should set to appropriate
-	// ControllerServiceCapability RPC types.
 	n.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,

--- a/pkg/nfs/nfs_test.go
+++ b/pkg/nfs/nfs_test.go
@@ -45,7 +45,7 @@ func NewEmptyDriver(emptyField string) *Driver {
 	case "name":
 		d = &Driver{
 			name:    "",
-			version: version,
+			version: driverVersion,
 			nodeID:  fakeNodeID,
 			cap:     map[csi.VolumeCapability_AccessMode_Mode]bool{},
 			perm:    perm,
@@ -53,7 +53,7 @@ func NewEmptyDriver(emptyField string) *Driver {
 	default:
 		d = &Driver{
 			name:    DefaultDriverName,
-			version: version,
+			version: driverVersion,
 			nodeID:  fakeNodeID,
 			cap:     map[csi.VolumeCapability_AccessMode_Mode]bool{},
 			perm:    perm,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -68,7 +68,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	handleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 
-	nfsDriver = nfs.NewNFSdriver(nodeID, nfs.DefaultDriverName, fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), perm)
+	nfsDriver = nfs.NewDriver(nodeID, nfs.DefaultDriverName, fmt.Sprintf("unix:///tmp/csi-%s.sock", uuid.NewUUID().String()), perm)
 	controllerServer = nfs.NewControllerServer(nfsDriver)
 
 	// install nfs server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: driver version print in logging

```console
DRIVER INFORMATION:
-------------------
Build Date: "2021-12-07T07:40:50Z"
Compiler: gc
Driver Name: nfs.csi.k8s.io
Driver Version: v3.1.0
Git Commit: 9ab192ba31631ea1baac813ef96005e78a38d6fe
Go Version: go1.16
Platform: linux/amd64

Streaming logs below:
I1207 07:43:02.286214   26063 server.go:117] Listening for connections on address: &net.UnixAddr{Name:"/tmp/csi.sock", Net:"unix"}

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: driver version print in logging
```
