### PR TITLE
update base image version of plugin binary to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 # Architecture for bin folder
 ARG ARCH
@@ -23,6 +23,6 @@ COPY bin/${ARCH}/nfsplugin /nfsplugin
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install ca-certificates mount nfs-common netbase
 # install updated packages to fix CVE issues
-RUN clean-install libssl1.1 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libgmp10
+RUN clean-install libssl1.1 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libgmp10 bsdutils
 
 ENTRYPOINT ["/nfsplugin"]


### PR DESCRIPTION
```
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| bsdutils | CVE-2021-3995    | MEDIUM   | 2.36.1-8          | 2.36.1-8+deb11u1 | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of FUSE filesystems belonging        |
|          |                  |          |                   |                  | to users with similar uid...         |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3995 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2021-3996    |          |                   |                  | util-linux: Unauthorized unmount     |
|          |                  |          |                   |                  | of filesystems in libmount           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-3996 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


-->
```release-note
NONE
```
