### PR TITLE
chore: fix pushing image pipeline broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 ARG ARCH
 
 # Copy nfsplugin from build _output directory
-COPY bin/${ARCH}/nfsplugin /nfsplugin
+COPY ./bin/${ARCH}/nfsplugin /nfsplugin
 
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install ca-certificates mount nfs-common netbase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
trying to fix following image push error:

https://storage.googleapis.com/kubernetes-jenkins/logs/post-csi-driver-nfs-push-images/1505022117538697216/build-log.txt
```
Dockerfile:21
--------------------
  19 |     
  20 |     # Copy nfsplugin from build _output directory
  21 | >>> COPY bin/${ARCH}/nfsplugin /nfsplugin
  22 |     
  23 |     RUN apt update && apt-mark unhold libcap2
--------------------
error: failed to solve: failed to compute cache key: failed to calculate checksum of ref iiep4siygqcc5hgky6t6fme3l::ghhr8b16cjp4zwohx9ri9j1p1: "/bin/amd64/nfsplugin": not found
+ docker buildx rm multiarchimage-buildertest
make: *** [release-tools/build.make:149: push-multiarch-nfsplugin] Error 1
ERROR
ERROR: build step 0 "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55" failed: step exited with non-zero status: 2
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
