### PR TITLE
fix: post-csi-driver-nfs-push-images failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@
 
 FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
-# Architecture for bin folder
 ARG ARCH
-
-# Copy nfsplugin from build _output directory
-COPY ./bin/${ARCH}/nfsplugin /nfsplugin
+ARG binary=./bin/${ARCH}/nfsplugin
+COPY ${binary} /nfsplugin
 
 RUN apt update && apt-mark unhold libcap2
 RUN clean-install ca-certificates mount nfs-common netbase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
fix: post-csi-driver-nfs-push-images failure

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #296

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
