### PR TITLE
feat: volume clone from source volume

### DIFF
--- a/deploy/example/pvc-volume-clone.yaml
+++ b/deploy/example/pvc-volume-clone.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-nfs-clone
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: nfs-csi
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: pvc-nfs-dynamic

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -325,6 +325,13 @@ func TestControllerGetCapabilities(t *testing.T) {
 							},
 						},
 					},
+					{
+						Type: &csi.ControllerServiceCapability_Rpc{
+							Rpc: &csi.ControllerServiceCapability_RPC{
+								Type: csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+							},
+						},
+					},
 				},
 			},
 			expectedErr: nil,

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -84,6 +84,7 @@ func NewDriver(options *DriverOptions) *Driver {
 	n.AddControllerServiceCapabilities([]csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+		csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
 	})
 
 	n.AddNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{

--- a/test/external-e2e/testdriver.yaml
+++ b/test/external-e2e/testdriver.yaml
@@ -12,6 +12,7 @@ DriverInfo:
     multipods: true
     RWX: true
     fsGroup: true
+    pvcDataSource: true
 InlineVolumes:
 - Attributes:
     server: nfs-server.default.svc.cluster.local


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR introduces a first step towards supporting snapshots - volume cloning from other volumes. It's implemented as outlined in https://github.com/kubernetes-csi/csi-driver-nfs/issues/30#issuecomment-617496994, and it is just an invocation of `cp -a [src]/. [dst]` to recursively copy the content of the source volume to the destination volume and adequately treat soft and hard links.

I would like to first get a consensus on the design decisions and then I can follow up with snapshots and volume copy from snapshots.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
first step towards implementing https://github.com/kubernetes-csi/csi-driver-nfs/issues/31

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
feat: volume clone from source volume
```
