### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/test/external-e2e/run.sh
+++ b/test/external-e2e/run.sh
@@ -25,7 +25,7 @@ install_ginkgo () {
 
 setup_e2e_binaries() {
     # download k8s external e2e binary
-    curl -sL https://storage.googleapis.com/kubernetes-release/release/v1.24.0/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
+    curl -sL https://dl.k8s.io/release/v1.24.0/kubernetes-test-linux-amd64.tar.gz --output e2e-tests.tar.gz
     tar -xvf e2e-tests.tar.gz && rm e2e-tests.tar.gz
 
     export EXTRA_HELM_OPTIONS="--set driver.name=$DRIVER.csi.k8s.io --set controller.name=csi-$DRIVER-controller --set node.name=csi-$DRIVER-node --set feature.enableInlineVolume=true"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

**Which issue(s) this PR fixes**:

Related PRs:

- https://github.com/kubernetes-sigs/image-builder/pull/656
- https://github.com/kubernetes-sigs/cluster-api/pull/4958

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
none
```
