### PR TITLE
fix: restore pvc from snapshot path issue

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -504,7 +504,7 @@ func (cs *ControllerServer) copyFromSnapshot(ctx context.Context, req *csi.Creat
 
 	// untar snapshot archive to dst path
 	snapPath := filepath.Join(getInternalVolumePath(cs.Driver.workingMountDir, snapVol), snap.archivePath())
-	dstPath := getInternalVolumePath(cs.Driver.workingMountDir, dstVol)
+	dstPath := getInternalMountPath(cs.Driver.workingMountDir, dstVol)
 	klog.V(2).Infof("copy volume from snapshot %v -> %v", snapPath, dstPath)
 	out, err := exec.Command("tar", "-xzvf", snapPath, "-C", dstPath).CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: restore pvc from snapshot path issue

When restore pvc from snapshot, it should create volume under root path instead of creating sub dir.

original restore snapshot pvc path:
```
[pod/csi-test-controller-7877f9cf75-dxwvp/nfs] I0601 11:56:46.854011       1 controllerserver.go:508] copy volume from snapshot /tmp/snapshot-409d145b-b54c-4f87-8201-66b7dcfa7eee/snapshot-409d145b-b54c-4f87-8201-66b7dcfa7eee/pvc-3e56ab2b-23b8-4002-92c8-efae68ef869e.tar.gz -> /tmp/pvc-cf042a57-1308-4c3d-9c5c-8a9173b6e418/pvc-cf042a57-1308-4c3d-9c5c-8a9173b6e418
[pod/csi-test-controller-7877f9cf75-dxwvp/nfs] I0601 11:56:46.858532       1 controllerserver.go:513] volume copied from snapshot /tmp/snapshot-409d145b-b54c-4f87-8201-66b7dcfa7eee/snapshot-409d145b-b54c-4f87-8201-66b7dcfa7eee/pvc-3e56ab2b-23b8-4002-92c8-efae68ef869e.tar.gz -> /tmp/pvc-cf042a57-1308-4c3d-9c5c-8a9173b6e418/pvc-cf042a57-1308-4c3d-9c5c-8a9173b6e418
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #459

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: restore pvc from snapshot path issue
```
