### PR TITLE
go.mod: Fix unresolvable indirect dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.9
 	k8s.io/cri-api => k8s.io/cri-api v0.26.9
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.9
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.9
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.9
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.9
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.9

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1062,6 +1062,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => k8s.io/controller-manager v0.26.9
 # k8s.io/cri-api => k8s.io/cri-api v0.26.9
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.9
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.9
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.9
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.9
 # k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.9


### PR DESCRIPTION
Fix `go list -mod=readonly -m all` by adding a replace for `k8s.io/dynamic-resource-allocation` that points to the Kubernetes version currently in use.

The packages is not used here, but making the dependency resolvable makes the go toolchain happy.

cf.: https://github.com/kubernetes/kubernetes/blob/4b48ab1fdbdeee3568790e44bea55ea719205025/go.mod#L265

```release-note
none
```
