### PR TITLE
cleanup: remove unnecessary getArchivedInternalVolumePath func

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -243,9 +243,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		internalVolumePath := getInternalVolumePath(cs.Driver.workingMountDir, nfsVol)
 
 		if strings.EqualFold(nfsVol.onDelete, archive) {
-			archivedNfsVol := *nfsVol
-			archivedNfsVol.subDir = "archived-" + nfsVol.subDir
-			archivedInternalVolumePath := getArchivedInternalVolumePath(cs.Driver.workingMountDir, nfsVol, &archivedNfsVol)
+			archivedInternalVolumePath := filepath.Join(getInternalMountPath(cs.Driver.workingMountDir, nfsVol), "archived-"+nfsVol.subDir)
 
 			// archive subdirectory under base-dir
 			klog.V(2).Infof("archiving subdirectory %s --> %s", internalVolumePath, archivedInternalVolumePath)
@@ -684,10 +682,6 @@ func getInternalMountPath(workingMountDir string, vol *nfsVolume) string {
 //     share, it's simpler to just do a mount per request.
 func getInternalVolumePath(workingMountDir string, vol *nfsVolume) string {
 	return filepath.Join(getInternalMountPath(workingMountDir, vol), vol.subDir)
-}
-
-func getArchivedInternalVolumePath(workingMountDir string, vol *nfsVolume, archVol *nfsVolume) string {
-	return filepath.Join(getInternalMountPath(workingMountDir, vol), archVol.subDir)
 }
 
 // Given a nfsVolume, return a CSI volume id


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
cleanup: remove unnecessary getArchivedInternalVolumePath func

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
