### PR TITLE
charts: fix master and control-plane nodeSelectors

### DIFF
--- a/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -31,10 +31,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         {{- if .Values.controller.runOnMaster}}
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: "true"
         {{- end}}
         {{- if .Values.controller.runOnControlPlane}}
-        node-role.kubernetes.io/control-plane: ""
+        node-role.kubernetes.io/control-plane: "true"
         {{- end}}
 {{- with .Values.controller.nodeSelector }}
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`controller.runOnMaster` and `controller.runOnControlPlane` are non-functional as written, since an empty value in a nodeSelector is not treated as a wildcard. Fix the nodeSelectors to match against `"true"`, which is enough to successfully schedule the controller on a master/control-plane node in my testing.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
