### PR TITLE
Fix org name in links to snapshot resources

### DIFF
--- a/deploy/example/snapshot/README.md
+++ b/deploy/example/snapshot/README.md
@@ -19,8 +19,8 @@ outfile
 
 ## Create a snapshot on source PVC
 ```console
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/csi-driver-nfs/master/deploy/example/snapshot/snapshotclass-nfs.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/csi-driver-nfs/master/deploy/example/snapshot/snapshot-nfs-dynamic.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/snapshot/snapshotclass-nfs.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/snapshot/snapshot-nfs-dynamic.yaml
 ```
 - Check snapshot Status
 
@@ -61,8 +61,8 @@ Events:
 ## Create a new PVC based on snapshot
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/csi-driver-nfs/master/deploy/example/snapshot/pvc-nfs-snapshot-restored.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/csi-driver-nfs/master/deploy/example/snapshot/nginx-pod-restored-snapshot.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/snapshot/pvc-nfs-snapshot-restored.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/snapshot/nginx-pod-restored-snapshot.yaml
 ```
 
  - Check data


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes broken links referencing old GitHub organization name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
