### PR TITLE
Update README.md

### DIFF
--- a/deploy/example/nfs-provisioner/README.md
+++ b/deploy/example/nfs-provisioner/README.md
@@ -6,10 +6,21 @@ There are multiple different NFS servers you can use for testing of
 the plugin, the major versions of the protocol v2, v3 and v4 should be supported
 by the current implementation. This page will show you how to set up a NFS Server deployment on a Kubernetes cluster.
 
-- To create a NFS provisioner on your Kubernetes cluster, run the following command.
+- (For linux/amd64) To create a NFS provisioner on your Kubernetes cluster, run the following command.
 
 ```bash
 kubectl create -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/nfs-provisioner/nfs-server.yaml
+```
+
+- (For linux/arm) To create a NFS provisioner on your Kubernetes cluster, run the following command.
+
+```bash
+git clone https://github.com/sjiveson/nfs-server-alpine.git
+cd nfs-server-alpine
+docker built -t <your-name>/nfs-server-alpine:latest-arm .
+wget https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/deploy/example/nfs-provisioner/nfs-server.yaml
+sed -i 's/<your-name>/itsthenetwork/' nfs-server.yaml
+kubectl create -f nfs-server.yaml
 ```
 
 - During the deployment, a new service `nfs-server` will be created which exposes the NFS server endpoint `nfs-server.default.svc.cluster.local` and the share path `/`. You can specify `PersistentVolume` or `StorageClass` using these information.


### PR DESCRIPTION
Adding methods to config nfs-provisioner on Linux/ARM machines.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:

The Docker image used in the `nfs-server.yaml` file, specifically `itsthenetwork/nfs-server-alpine`, has the tag `latest` and is exclusively designed for `linux/amd64` architectures. Although there are tag versions available for `linux/arm` architectures in [docker hub](https://hub.docker.com/r/itsthenetwork/nfs-server-alpine), the image with `linux/arm` tag fails to function properly on OpenEuler 22.03 LTS armv8 machines. I speculate that this might be due to the fact that the `linux/arm` version is actually optimized for Apple's chips, hence its incompatibility with generic ARM machines.

So I've added instructions to `deploy/example/nfs-provisioner/README.md` on how to manually create an NFS server image and modify the nfs-server.yaml file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
