### PR TITLE
doc: missing keyword pod in command

### DIFF
--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -11,7 +11,7 @@ csi-nfs-controller-56bfddd689-sl4ll      5/5     Running   0          35s     10
 ```
  - get pod description and logs
 ```console
-$ kubectl describe csi-nfs-controller-56bfddd689-dh5tk -n kube-system > csi-nfs-controller-description.log
+$ kubectl describe pod csi-nfs-controller-56bfddd689-dh5tk -n kube-system > csi-nfs-controller-description.log
 $ kubectl logs csi-nfs-controller-56bfddd689-dh5tk -c nfs -n kube-system > csi-nfs-controller.log
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation


**What this PR does / why we need it**:
the getting pod description command is missing keyword 'pod' 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
