### PR TITLE
do not generate snapshotter container if enabled: false

### DIFF
--- a/charts/v4.9.0/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/charts/v4.9.0/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -86,6 +86,7 @@ spec:
             capabilities:
               drop:
               - ALL
+{{- if .Values.externalSnapshotter.enabled }}
         - name: csi-snapshotter
 {{- if hasPrefix "/" .Values.image.csiSnapshotter.repository }}
           image: "{{ .Values.image.baseRepo }}{{ .Values.image.csiSnapshotter.repository }}:{{ .Values.image.csiSnapshotter.tag }}"
@@ -110,6 +111,7 @@ spec:
             capabilities:
               drop:
               - ALL
+{{- end }}
         - name: liveness-probe
 {{- if hasPrefix "/" .Values.image.livenessProbe.repository }}
           image: "{{ .Values.image.baseRepo }}{{ .Values.image.livenessProbe.repository }}:{{ .Values.image.livenessProbe.tag }}"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Do not include snapshotter container unless .externalSnapshotter.enabled is true

**Does this PR introduce a user-facing change?**:
```release-note
none
```
