### PR TITLE
fix: only remove root of SubDir when OnDelete is deleteRootSubDir

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -292,15 +292,16 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			}
 			klog.V(2).Infof("archived subdirectory %s --> %s", internalVolumePath, archivedInternalVolumePath)
 		} else {
-			rootDir := getRootDir(nfsVol.subDir)
-			if rootDir != "" {
-				rootDir = filepath.Join(getInternalMountPath(cs.Driver.workingMountDir, nfsVol), rootDir)
-			} else {
-				rootDir = internalVolumePath
+			deleteDir := internalVolumePath
+			if strings.EqualFold(nfsVol.onDelete, deleteRootSubDir) {
+				rootDir := getRootDir(nfsVol.subDir)
+				if rootDir != "" {
+					deleteDir = filepath.Join(getInternalMountPath(cs.Driver.workingMountDir, nfsVol), rootDir)
+				}
 			}
 			// delete subdirectory under base-dir
-			klog.V(2).Infof("removing subdirectory at %v on internalVolumePath %s", rootDir, internalVolumePath)
-			if err = os.RemoveAll(rootDir); err != nil {
+			klog.V(2).Infof("removing subdirectory at %v on internalVolumePath %s", deleteDir, internalVolumePath)
+			if err = os.RemoveAll(deleteDir); err != nil {
 				return nil, status.Errorf(codes.Internal, "delete subdirectory(%s) failed with %v", internalVolumePath, err)
 			}
 		}

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -38,19 +38,20 @@ import (
 )
 
 const (
-	testServer                   = "test-server"
-	testBaseDir                  = "test-base-dir"
-	testBaseDirNested            = "test/base/dir"
-	testCSIVolume                = "volume-name"
-	testVolumeID                 = "test-server/test-base-dir/volume-name"
-	newTestVolumeID              = "test-server#test-base-dir#volume-name##"
-	newTestVolumeWithVolumeID    = "test-server#test-base-dir#volume-name#volume-name#"
-	testVolumeIDNested           = "test-server/test/base/dir/volume-name"
-	newTestVolumeIDNested        = "test-server#test/base/dir#volume-name#"
-	newTestVolumeIDUUID          = "test-server#test-base-dir#volume-name#uuid"
-	newTestVolumeOnDeleteRetain  = "test-server#test-base-dir#volume-name#uuid#retain"
-	newTestVolumeOnDeleteDelete  = "test-server#test-base-dir#volume-name#uuid#delete"
-	newTestVolumeOnDeleteArchive = "test-server#test-base-dir#volume-name##archive"
+	testServer                            = "test-server"
+	testBaseDir                           = "test-base-dir"
+	testBaseDirNested                     = "test/base/dir"
+	testCSIVolume                         = "volume-name"
+	testVolumeID                          = "test-server/test-base-dir/volume-name"
+	newTestVolumeID                       = "test-server#test-base-dir#volume-name##"
+	newTestVolumeWithVolumeID             = "test-server#test-base-dir#volume-name#volume-name#"
+	testVolumeIDNested                    = "test-server/test/base/dir/volume-name"
+	newTestVolumeIDNested                 = "test-server#test/base/dir#volume-name#"
+	newTestVolumeIDUUID                   = "test-server#test-base-dir#volume-name#uuid"
+	newTestVolumeOnDeleteRetain           = "test-server#test-base-dir#volume-name#uuid#retain"
+	newTestVolumeOnDeleteDelete           = "test-server#test-base-dir#volume-name#uuid#delete"
+	newTestVolumeOnDeleteDeleteRootSubDir = "test-server#test-base-dir#volume-name#uuid#deleterootsubdir"
+	newTestVolumeOnDeleteArchive          = "test-server#test-base-dir#volume-name##archive"
 )
 
 func initTestController(_ *testing.T) *ControllerServer {
@@ -507,6 +508,19 @@ func TestNfsVolFromId(t *testing.T) {
 				subDir:   testCSIVolume,
 				uuid:     "uuid",
 				onDelete: "delete",
+			},
+			expectErr: false,
+		},
+		{
+			name:     "valid request nested ondelete deleterootsubdir",
+			volumeID: newTestVolumeOnDeleteDeleteRootSubDir,
+			resp: &nfsVolume{
+				id:       newTestVolumeOnDeleteDeleteRootSubDir,
+				server:   testServer,
+				baseDir:  testBaseDir,
+				subDir:   testCSIVolume,
+				uuid:     "uuid",
+				onDelete: "deleterootsubdir",
 			},
 			expectErr: false,
 		},

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -39,10 +39,11 @@ const (
 	delete                          = "delete"
 	retain                          = "retain"
 	archive                         = "archive"
+	deleteRootSubDir                = "deleteRootSubDir"
 	volumeOperationAlreadyExistsFmt = "An operation with the given Volume ID %s already exists"
 )
 
-var supportedOnDeleteValues = []string{"", delete, retain, archive}
+var supportedOnDeleteValues = []string{"", delete, retain, archive, deleteRootSubDir}
 
 func validateOnDeleteValue(onDelete string) error {
 	for _, v := range supportedOnDeleteValues {

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -335,6 +335,11 @@ func TestValidateOnDeleteValue(t *testing.T) {
 			expected: nil,
 		},
 		{
+			desc:     "Delete value",
+			onDelete: "DeleteRootSubDir",
+			expected: nil,
+		},
+		{
 			desc:     "Archive value",
 			onDelete: "Archive",
 			expected: nil,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,6 +66,7 @@ var (
 		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
 		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
 		"mountPermissions": "0755",
+		"onDelete":         "deleteRootSubDir",
 	}
 	retainStorageClassParameters = map[string]string{
 		"server": nfsServerAddress,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: only remove root of SubDir when OnDelete is deleteRootSubDir

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #855

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: only remove root of SubDir when OnDelete is deleteRootSubDir
```
