### PR TITLE
chore: create voume/snapshot should respect mountOptions in secret

### DIFF
--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -289,3 +289,21 @@ func WaitUntilTimeout(timeout time.Duration, execFunc ExecFunc, timeoutFunc Time
 		return timeoutFunc()
 	}
 }
+
+// getVolumeCapabilityFromSecret retrieves the volume capability from the secret
+// if secret contains mountOptions, it will return the volume capability
+// if secret does not contain mountOptions, it will return nil
+func getVolumeCapabilityFromSecret(volumeID string, secret map[string]string) *csi.VolumeCapability {
+	mountOptions := getMountOptions(secret)
+	if mountOptions != "" {
+		klog.V(2).Infof("found mountOptions(%s) for volume(%s)", mountOptions, volumeID)
+		return &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{
+					MountFlags: []string{mountOptions},
+				},
+			},
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
fix: create voume/snapshot should respect mountOptions in secret, thus user could only set mountOptions in secret for both create and delete volume/snapshot

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: create voume/snapshot should respect mountOptions in secret
```
