### PR TITLE
Release tool update

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
 /kind bug

Squashed 'release-tools/' changes from 53344305..74502e54
74502e54 Merge pull request https://github.com/kubernetes-csi/csi-driver-nfs/issues/278 from liangyuanpeng/migrate_k8s_testimages
5ec1a52b use gcr.io/k8s-staging-test-infra instead of gcr.io/k8s-testimages

git-subtree-dir: release-tools
git-subtree-split: 74502e544bc6a17820892c0d490e8f0b59462998

