### PR TITLE
feat: authentication with Kerberos credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.6
+FROM debian:stable-slim
 
 ARG ARCH
 ARG binary=./bin/${ARCH}/nfsplugin
 COPY ${binary} /nfsplugin
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates mount nfs-common netbase krb5-user
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && apt-get install -y --reinstall --purge ca-certificates mount nfs-common netbase krb5-user lsb-base bash
 
 RUN cat > /etc/default/nfs-common <<EOC
 NEED_STATD=yes
@@ -28,4 +28,18 @@ NEED_IDMAPD=yes
 NEED_GSSD=yes
 EOC
 
-ENTRYPOINT ["/nfsplugin"]
+RUN cat > /usr/local/bin/entry.sh <<'EOF'
+#!/bin/sh
+set -x
+
+if [ "$1" = "true" ]; then
+	shift 1
+	service rpcbind start
+	service nfs-common start
+fi
+
+/nfsplugin $@
+EOF
+RUN chmod +x /usr/local/bin/entry.sh
+
+ENTRYPOINT ["entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ if [ "$1" = "true" ]; then
 	shift 1
 	service rpcbind start
 	service nfs-common start
+	sleep 5
 fi
 
 /nfsplugin $@

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,14 @@ ARG ARCH
 ARG binary=./bin/${ARCH}/nfsplugin
 COPY ${binary} /nfsplugin
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates mount nfs-common netbase
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates mount nfs-common netbase krb5-user
+
+RUN cat > /etc/default/nfs-common <<EOC
+NEED_STATD=yes
+
+NEED_IDMAPD=yes
+
+NEED_GSSD=yes
+EOC
 
 ENTRYPOINT ["/nfsplugin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,11 @@ set -x
 
 if [ "$1" = "true" ]; then
 	shift 1
+fi
 
 	# Debian 13 sysvinit scripts assume systemd-created runtime dirs.
 	# Create the paths they touch so `service rpcbind start` doesn't fail.
-	mkdir -p /run/sendsigs.omit.d /var/lib/nfs/rpc_pipefs /var/lib/nfs/statd /var/lib/nfs/v4recovery /run/rpc_pipefs
+	mkdir -p /run/sendsigs.omit.d /var/lib/nfs/statd /var/lib/nfs/v4recovery /run/rpc_pipefs
 
 	# rpc.gssd needs rpc_pipefs mounted; nfs-common sysvinit will happily
 	# report "gssd." as started even when it isn't, causing sec=krb5 mounts
@@ -55,7 +56,6 @@ if [ "$1" = "true" ]; then
 	fi
 
 	sleep 5
-fi
 
 /nfsplugin $@
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ if [ "$1" = "true" ]; then
 
 	# Debian 13 sysvinit scripts assume systemd-created runtime dirs.
 	# Create the paths they touch so `service rpcbind start` doesn't fail.
-	mkdir -p /run/sendsigs.omit.d /var/lib/nfs/rpc_pipefs /var/lib/nfs/statd /var/lib/nfs/v4recovery
+	mkdir -p /run/sendsigs.omit.d /var/lib/nfs/rpc_pipefs /var/lib/nfs/statd /var/lib/nfs/v4recovery /run/rpc_pipefs
 
 	# rpc.gssd needs rpc_pipefs mounted; nfs-common sysvinit will happily
 	# report "gssd." as started even when it isn't, causing sec=krb5 mounts
 	# to hang forever. Mount it explicitly.
-	if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
-		mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs || true
+	if ! mountpoint -q /run/rpc_pipefs; then
+		mount -t rpc_pipefs sunrpc /run/rpc_pipefs || true
 	fi
 
 	service rpcbind start || rpcbind -w || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8
+FROM debian:stable-slim
 
 ARG ARCH
 ARG binary=./bin/${ARCH}/nfsplugin
 COPY ${binary} /nfsplugin
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && clean-install ca-certificates mount nfs-common netbase krb5-user
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && apt-get install -y --reinstall --purge ca-certificates mount nfs-common netbase krb5-user lsb-base bash
 
 RUN cat > /etc/default/nfs-common <<EOC
 NEED_STATD=yes
@@ -28,4 +28,18 @@ NEED_IDMAPD=yes
 NEED_GSSD=yes
 EOC
 
-ENTRYPOINT ["/nfsplugin"]
+RUN cat > /usr/local/bin/entry.sh <<'EOF'
+#!/bin/sh
+set -x
+
+if [ "$1" = "true" ]; then
+	shift 1
+	service rpcbind start
+	service nfs-common start
+fi
+
+/nfsplugin $@
+EOF
+RUN chmod +x /usr/local/bin/entry.sh
+
+ENTRYPOINT ["entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG ARCH
 ARG binary=./bin/${ARCH}/nfsplugin
 COPY ${binary} /nfsplugin
 
-RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && apt-get install -y --reinstall --purge ca-certificates mount nfs-common netbase krb5-user lsb-base bash
+RUN apt update && apt upgrade -y && apt-mark unhold libcap2 && apt-get install -y --reinstall --purge ca-certificates mount nfs-common netbase krb5-user lsb-base bash procps
 
 RUN cat > /etc/default/nfs-common <<EOC
 NEED_STATD=yes
@@ -34,8 +34,26 @@ set -x
 
 if [ "$1" = "true" ]; then
 	shift 1
-	service rpcbind start
-	service nfs-common start
+
+	# Debian 13 sysvinit scripts assume systemd-created runtime dirs.
+	# Create the paths they touch so `service rpcbind start` doesn't fail.
+	mkdir -p /run/sendsigs.omit.d /var/lib/nfs/rpc_pipefs /var/lib/nfs/statd /var/lib/nfs/v4recovery
+
+	# rpc.gssd needs rpc_pipefs mounted; nfs-common sysvinit will happily
+	# report "gssd." as started even when it isn't, causing sec=krb5 mounts
+	# to hang forever. Mount it explicitly.
+	if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
+		mount -t rpc_pipefs sunrpc /var/lib/nfs/rpc_pipefs || true
+	fi
+
+	service rpcbind start || rpcbind -w || true
+	service nfs-common start || true
+
+	# Belt-and-suspenders: make sure rpc.gssd is actually running.
+	if ! pgrep -x rpc.gssd >/dev/null 2>&1; then
+		/usr/sbin/rpc.gssd -v || true
+	fi
+
 	sleep 5
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ install-nfs-server:
 	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-server.yaml
 	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-krb-server.yaml
 	kubectl delete secret mount-options -n default --ignore-not-found
-	kubectl create secret generic mount-options --from-literal mountOptions="nfsvers=4.1" --from-literal krb-pwd='password!' -n default
+	kubectl create secret generic mount-options --from-literal mountOptions="nfsvers=4.1" --from-literal krb-pwd='password!' --from-file=krb5.conf=./test/krb5.conf -n default
 
 .PHONY: install-helm
 install-helm:

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,9 @@ endif
 .PHONY: install-nfs-server
 install-nfs-server:
 	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-server.yaml
+	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-krb-server.yaml
 	kubectl delete secret mount-options -n default --ignore-not-found
-	kubectl create secret generic mount-options --from-literal mountOptions="nfsvers=4.1" -n default
+	kubectl create secret generic mount-options --from-literal mountOptions="nfsvers=4.1" --from-literal krb-pwd='password!' -n default
 
 .PHONY: install-helm
 install-helm:

--- a/Makefile
+++ b/Makefile
@@ -131,9 +131,7 @@ endif
 .PHONY: install-nfs-server
 install-nfs-server:
 	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-server.yaml
-	kubectl apply -f ./deploy/example/nfs-provisioner/nfs-krb-server.yaml
-	kubectl delete secret mount-options -n default --ignore-not-found
-	kubectl create secret generic mount-options --from-literal mountOptions="nfsvers=4.1" --from-literal krb-pwd='password!' --from-file=krb5.conf=./test/krb5.conf -n default
+	./test/utils/setup-krb.sh
 
 .PHONY: install-helm
 install-helm:

--- a/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -174,6 +174,7 @@ spec:
             allowPrivilegeEscalation: true
           imagePullPolicy: {{ .Values.image.nfs.pullPolicy }}
           args:
+            - 'true' # needed to distinguish controller from node
             - "--v={{ .Values.controller.logLevel }}"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/charts/latest/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -176,6 +176,7 @@ spec:
             allowPrivilegeEscalation: true
           imagePullPolicy: {{ .Values.image.nfs.pullPolicy }}
           args:
+            - 'true' # needed to distinguish controller from node
             - "--v={{ .Values.controller.logLevel }}"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/csi-nfs-controller.yaml
+++ b/deploy/csi-nfs-controller.yaml
@@ -157,6 +157,7 @@ spec:
             allowPrivilegeEscalation: true
           imagePullPolicy: IfNotPresent
           args:
+            - "true"
             - "-v=5"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/csi-nfs-controller.yaml
+++ b/deploy/csi-nfs-controller.yaml
@@ -163,6 +163,7 @@ spec:
             allowPrivilegeEscalation: true
           imagePullPolicy: IfNotPresent
           args:
+            - "true"
             - "-v=5"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -44,12 +44,11 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: nfs-krb-server
-          image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
+          image: docker.io/thealmightydrawingtablet/nfs-krb:ubuntu
           command:
             - bash
             - -c
-            - ./init.sh & sleep 10; tail -f /var/log/messages /var/log/rpc-gssd.log
-              /var/log/gssd.log
+            - ./init.sh ubuntu & sleep 10; tail -f /var/log/syslog 
           env:
             - name: SHARED_DIRECTORY
               value: /srv/shared

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -22,7 +22,7 @@ spec:
       protocol: TCP
     - name: tcp-749
       port: 749
-      protocol: TCP 
+      protocol: TCP
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -41,17 +41,18 @@ spec:
         app: nfs-krb-server
     spec:
       nodeSelector:
-        "kubernetes.io/os": linux
+        kubernetes.io/os: linux
       containers:
         - name: nfs-krb-server
           image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
           command:
             - bash
             - -c
-            - "./init.sh & sleep 10; tail -f /var/log/messages /var/log/rpc-gssd.log /var/log/gssd.log"
+            - ./init.sh & sleep 10; tail -f /var/log/messages /var/log/rpc-gssd.log
+              /var/log/gssd.log
           env:
             - name: SHARED_DIRECTORY
-              value: "/srv/shared"
+              value: /srv/shared
             - name: NFS_KRB_REALM
               value: NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
             - name: NFS_KRB_PRINC
@@ -59,7 +60,7 @@ spec:
             - name: NFS_KRB_PWD
               valueFrom:
                 secretKeyRef:
-                  name: mount-options 
+                  name: mount-options
                   key: krb-pwd
           volumeMounts:
             - mountPath: /srv/shared

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -1,0 +1,82 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-krb-server
+  namespace: default
+  labels:
+    app: nfs-krb-server
+spec:
+  type: ClusterIP  # use "LoadBalancer" to get a public ip
+  selector:
+    app: nfs-krb-server
+  ports:
+    - name: tcp-2049
+      port: 2049
+      protocol: TCP
+    - name: udp-111
+      port: 111
+      protocol: UDP
+    - name: tcp-88
+      port: 88
+      protocol: TCP
+    - name: tcp-749
+      port: 749
+      protocol: TCP 
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nfs-krb-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-krb-server
+  template:
+    metadata:
+      name: nfs-krb-server
+      labels:
+        app: nfs-krb-server
+    spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
+      containers:
+        - name: nfs-krb-server
+          image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
+          env:
+            - name: SHARED_DIRECTORY
+              value: "/srv/shared"
+            - name: NFS_KRB_REALM
+              value: NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
+            - name: NFS_KRB_PRINC
+              value: nfs/nfs-krb-server.default.svc.cluster.local
+            - name: NFS_KRB_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: krb-pwd
+                  key: value
+          volumeMounts:
+            - mountPath: /srv/shared
+              name: nfs-vol
+          securityContext:
+            privileged: true
+          ports:
+            - name: tcp-2049
+              containerPort: 2049
+              protocol: TCP
+            - name: udp-111
+              containerPort: 111
+              protocol: UDP
+            - name: tcp-88
+              containerPort: 88
+              protocol: TCP
+            - name: tcp-749
+              containerPort: 749
+              protocol: TCP
+      volumes:
+        - name: nfs-vol
+          hostPath:
+            path: /srv/nfs-krb-vol  # modify this to specify another path to store nfs share data
+            type: DirectoryOrCreate

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -17,6 +17,9 @@ spec:
     - name: udp-111
       port: 111
       protocol: UDP
+    - name: tcp-111
+      port: 111
+      protocol: TCP
     - name: tcp-88
       port: 88
       protocol: TCP
@@ -44,11 +47,12 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: nfs-krb-server
-          image: docker.io/thealmightydrawingtablet/nfs-krb:ubuntu
+          image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
+          imagePullPolicy: Always
           command:
             - bash
             - -c
-            - ./init.sh ubuntu & sleep 10; tail -f /var/log/syslog 
+            - ./init.sh & sleep 10; ls /var/log; tail -f /var/log/messages /var/log/rpc-gssd.log
           env:
             - name: SHARED_DIRECTORY
               value: /srv/shared

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -45,6 +45,10 @@ spec:
       containers:
         - name: nfs-krb-server
           image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
+          command:
+            - bash
+            - -c
+            - "./init.sh & sleep 10; tail -f /var/log/messages /var/log/rpc-gssd.log /var/log/gssd.log"
           env:
             - name: SHARED_DIRECTORY
               value: "/srv/shared"

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -55,8 +55,8 @@ spec:
             - name: NFS_KRB_PWD
               valueFrom:
                 secretKeyRef:
-                  name: krb-pwd
-                  key: value
+                  name: mount-options 
+                  key: krb-pwd
           volumeMounts:
             - mountPath: /srv/shared
               name: nfs-vol

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -69,6 +69,9 @@ spec:
             - name: udp-111
               containerPort: 111
               protocol: UDP
+            - name: tcp-111
+              containerPort: 111
+              protocol: TCP
             - name: tcp-88
               containerPort: 88
               protocol: TCP

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -55,14 +55,14 @@ spec:
           command:
             - bash
             - -c
-            - ./init.sh & sleep 10; ls /var/log; tail -f /var/log/messages /var/log/rpc-gssd.log
+            - ./init.sh & sleep 10; ls /var/log; tail -f /var/log/messages /var/log/gssd.log
           env:
             - name: SHARED_DIRECTORY
               value: /srv/shared
             - name: NFS_KRB_REALM
               value: NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
             - name: NFS_KRB_PRINC
-              value: nfs/nfs-krb-server.default.svc.cluster.local
+              value: nfs/csi-nfs-client.default.svc.cluster.local
             - name: NFS_KRB_FQDN
               value: nfs-krb-server.default.svc.cluster.local
             - name: NFS_KRB_PWD

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -23,6 +23,9 @@ spec:
     - name: tcp-88
       port: 88
       protocol: TCP
+    - name: udp-88
+      port: 88
+      protocol: UDP
     - name: tcp-749
       port: 749
       protocol: TCP
@@ -83,6 +86,9 @@ spec:
             - name: tcp-88
               containerPort: 88
               protocol: TCP
+            - name: udp-88
+              containerPort: 88
+              protocol: UDP
             - name: tcp-749
               containerPort: 749
               protocol: TCP

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -63,6 +63,8 @@ spec:
               value: NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
             - name: NFS_KRB_PRINC
               value: nfs/nfs-krb-server.default.svc.cluster.local
+            - name: NFS_KRB_FQDN
+              value: nfs-krb-server.default.svc.cluster.local
             - name: NFS_KRB_PWD
               valueFrom:
                 secretKeyRef:

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -51,11 +51,22 @@ spec:
       containers:
         - name: nfs-krb-server
           image: docker.io/thealmightydrawingtablet/nfs-krb:alpine
-          imagePullPolicy: Always
-          command:
-            - bash
-            - -c
-            - ./init.sh & sleep 10; ls /var/log; tail -f /var/log/messages /var/log/gssd.log
+          imagePullPolicy: Always 
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - rpcinfo -t 127.0.0.1 nfs 4 >/dev/null
+            periodSeconds: 2
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - rpcinfo -t 127.0.0.1 nfs 4 >/dev/null
+            periodSeconds: 5
           env:
             - name: SHARED_DIRECTORY
               value: /srv/shared

--- a/deploy/example/nfs-provisioner/nfs-krb-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-krb-server.yaml
@@ -8,6 +8,7 @@ metadata:
     app: nfs-krb-server
 spec:
   type: ClusterIP  # use "LoadBalancer" to get a public ip
+  clusterIP: None
   selector:
     app: nfs-krb-server
   ports:
@@ -70,20 +71,24 @@ spec:
           env:
             - name: SHARED_DIRECTORY
               value: /srv/shared
+            - name: NFS_V4_DOMAIN
+              value: default.svc.cluster.local
             - name: NFS_KRB_REALM
               value: NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
-            - name: NFS_KRB_PRINC
-              value: nfs/csi-nfs-client.default.svc.cluster.local
-            - name: NFS_KRB_FQDN
+            - name: NFS_CLIENT_FQDN
+              value: csi-nfs-controller.kube-system.svc.cluster.local
+            - name: NFS_SERVER_FQDN
               value: nfs-krb-server.default.svc.cluster.local
-            - name: NFS_KRB_PWD
+            - name: KDC_MASTER_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: mount-options
                   key: krb-pwd
           volumeMounts:
-            - mountPath: /srv/shared
-              name: nfs-vol
+            - name: nfs-vol
+              mountPath: /srv/shared
+            - name: kerberos-client-config
+              mountPath: /shared
           securityContext:
             privileged: true
           ports:
@@ -109,4 +114,8 @@ spec:
         - name: nfs-vol
           hostPath:
             path: /srv/nfs-krb-vol  # modify this to specify another path to store nfs share data
+            type: DirectoryOrCreate
+        - name: kerberos-client-config
+          hostPath:
+            path: /srv/nfs-krb-client
             type: DirectoryOrCreate

--- a/deploy/example/nfs-provisioner/nfs-server.yaml
+++ b/deploy/example/nfs-provisioner/nfs-server.yaml
@@ -35,13 +35,13 @@ spec:
         app: nfs-server
     spec:
       nodeSelector:
-        "kubernetes.io/os": linux
+        kubernetes.io/os: linux
       containers:
         - name: nfs-server
           image: itsthenetwork/nfs-server-alpine:latest
           env:
             - name: SHARED_DIRECTORY
-              value: "/exports"
+              value: /exports
           volumeMounts:
             - mountPath: /exports
               name: nfs-vol

--- a/deploy/example/nfs-provisioner/nginx-pod.yaml
+++ b/deploy/example/nfs-provisioner/nginx-pod.yaml
@@ -9,11 +9,9 @@ metadata:
 spec:
   capacity:
     storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
+  accessModes: [ReadWriteOnce]
   persistentVolumeReclaimPolicy: Delete
-  mountOptions:
-    - nfsvers=4.1
+  mountOptions: [nfsvers=4.1]
   csi:
     driver: nfs.csi.k8s.io
     # volumeHandle format: {nfs-server-address}#{sub-dir-name}#{share-name}
@@ -29,13 +27,12 @@ metadata:
   name: pvc-nginx
   namespace: default
 spec:
-  accessModes:
-    - ReadWriteOnce
+  accessModes: [ReadWriteOnce]
   resources:
     requests:
       storage: 10Gi
   volumeName: pv-nginx
-  storageClassName: ""
+  storageClassName: ''
 ---
 apiVersion: v1
 kind: Pod

--- a/deploy/example/nfs-provisioner/nginx-pod.yaml
+++ b/deploy/example/nfs-provisioner/nginx-pod.yaml
@@ -9,11 +9,9 @@ metadata:
 spec:
   capacity:
     storage: 10Gi
-  accessModes:
-    - ReadWriteOnce
+  accessModes: [ReadWriteOnce]
   persistentVolumeReclaimPolicy: Delete
-  mountOptions:
-    - nfsvers=4.1
+  mountOptions: [nfsvers=4.1]
   csi:
     driver: nfs.csi.k8s.io
     # volumeHandle format: {nfs-server-address}#{share-name}#{sub-dir-name}
@@ -29,13 +27,12 @@ metadata:
   name: pvc-nginx
   namespace: default
 spec:
-  accessModes:
-    - ReadWriteOnce
+  accessModes: [ReadWriteOnce]
   resources:
     requests:
       storage: 10Gi
   volumeName: pv-nginx
-  storageClassName: ""
+  storageClassName: ''
 ---
 apiVersion: v1
 kind: Pod

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -142,6 +142,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case pvNameKey:
 		case paramKrbPrincipal:
 		case paramKrbPasswordSecret:
+		case paramKrbConf:
 			// no op
 		case mountPermissionsField:
 			if v != "" {
@@ -506,7 +507,7 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		VolumeContext:    volContext,
 		VolumeCapability: volCap,
 		VolumeId:         vol.id,
-		Secrets: secrets,
+		Secrets:          secrets,
 	})
 	return err
 }

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -140,6 +140,8 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case pvcNamespaceKey:
 		case pvcNameKey:
 		case pvNameKey:
+		case paramKrbPrincipal:
+		case paramKrbPasswordSecret:
 			// no op
 		case mountPermissionsField:
 			if v != "" {

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -144,6 +144,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case pvNameKey:
 		case paramKrbPrincipal:
 		case paramKrbPasswordSecret:
+		case paramKrbConf:
 			// no op
 		case mountPermissionsField:
 			if v != "" {
@@ -519,7 +520,7 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		VolumeContext:    volContext,
 		VolumeCapability: volCap,
 		VolumeId:         vol.id,
-		Secrets: secrets,
+		Secrets:          secrets,
 	})
 	return err
 }

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -143,7 +143,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case pvcNameKey:
 		case pvNameKey:
 		case paramKrbPrincipal:
-		case paramKrbPasswordSecret:
+		case paramKrbKeytab:
 		case paramKrbConf:
 			// no op
 		case mountPermissionsField:

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -172,7 +172,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		volCap = req.GetVolumeCapabilities()[0]
 	}
 	// Mount nfs base share so we can create a subdirectory
-	if err = cs.internalMount(ctx, nfsVol, parameters, volCap); err != nil {
+	if err = cs.internalMount(ctx, nfsVol, parameters, volCap, req.GetSecrets()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount nfs server: %v", err)
 	}
 	defer func() {
@@ -245,7 +245,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		}
 		// mount nfs base share so we can delete the subdirectory
 		volCap := getVolumeCapabilityFromSecret(volumeID, req.GetSecrets())
-		if err = cs.internalMount(ctx, nfsVol, nil, volCap); err != nil {
+		if err = cs.internalMount(ctx, nfsVol, nil, volCap, req.GetSecrets()); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to mount nfs server: %v", err)
 		}
 		defer func() {
@@ -369,7 +369,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	}
 	snapVol := volumeFromSnapshot(snapshot)
 	volCap := getVolumeCapabilityFromSecret(req.GetSourceVolumeId(), req.GetSecrets())
-	if err = cs.internalMount(ctx, snapVol, req.GetParameters(), volCap); err != nil {
+	if err = cs.internalMount(ctx, snapVol, req.GetParameters(), volCap, req.GetSecrets()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount snapshot nfs server: %v", err)
 	}
 	defer func() {
@@ -385,7 +385,7 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, err
 	}
 
-	if err = cs.internalMount(ctx, srcVol, req.GetParameters(), volCap); err != nil {
+	if err = cs.internalMount(ctx, srcVol, req.GetParameters(), volCap, req.GetSecrets()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount src nfs server: %v", err)
 	}
 	defer func() {
@@ -446,7 +446,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 
 	volCap := getVolumeCapabilityFromSecret(req.SnapshotId, req.GetSecrets())
 	vol := volumeFromSnapshot(snap)
-	if err = cs.internalMount(ctx, vol, nil, volCap); err != nil {
+	if err = cs.internalMount(ctx, vol, nil, volCap, req.GetSecrets()); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to mount nfs server for snapshot deletion: %v", err)
 	}
 	defer func() {
@@ -485,7 +485,7 @@ func (cs *ControllerServer) ControllerExpandVolume(_ context.Context, req *csi.C
 }
 
 // Mount nfs server at base-dir
-func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, volumeContext map[string]string, volCap *csi.VolumeCapability) error {
+func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, volumeContext map[string]string, volCap *csi.VolumeCapability, secrets map[string]string) error {
 	if volCap == nil {
 		volCap = &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Mount{
@@ -519,6 +519,7 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		VolumeContext:    volContext,
 		VolumeCapability: volCap,
 		VolumeId:         vol.id,
+		Secrets: secrets,
 	})
 	return err
 }
@@ -548,7 +549,7 @@ func (cs *ControllerServer) copyFromSnapshot(ctx context.Context, req *csi.Creat
 		volCap = req.GetVolumeCapabilities()[0]
 	}
 
-	if err = cs.internalMount(ctx, snapVol, nil, volCap); err != nil {
+	if err = cs.internalMount(ctx, snapVol, nil, volCap, req.GetSecrets()); err != nil {
 		return status.Errorf(codes.Internal, "failed to mount src nfs server for snapshot volume copy: %v", err)
 	}
 	defer func() {
@@ -556,7 +557,7 @@ func (cs *ControllerServer) copyFromSnapshot(ctx context.Context, req *csi.Creat
 			klog.Warningf("failed to unmount src nfs server after snapshot volume copy: %v", err)
 		}
 	}()
-	if err = cs.internalMount(ctx, dstVol, nil, volCap); err != nil {
+	if err = cs.internalMount(ctx, dstVol, nil, volCap, req.GetSecrets()); err != nil {
 		return status.Errorf(codes.Internal, "failed to mount dst nfs server for snapshot volume copy: %v", err)
 	}
 	defer func() {
@@ -611,7 +612,7 @@ func (cs *ControllerServer) copyFromVolume(ctx context.Context, req *csi.CreateV
 	if len(req.GetVolumeCapabilities()) > 0 {
 		volCap = req.GetVolumeCapabilities()[0]
 	}
-	if err = cs.internalMount(ctx, srcVol, nil, volCap); err != nil {
+	if err = cs.internalMount(ctx, srcVol, nil, volCap, req.GetSecrets()); err != nil {
 		return status.Errorf(codes.Internal, "failed to mount src nfs server: %v", err)
 	}
 	defer func() {
@@ -619,7 +620,7 @@ func (cs *ControllerServer) copyFromVolume(ctx context.Context, req *csi.CreateV
 			klog.Warningf("failed to unmount nfs server: %v", err)
 		}
 	}()
-	if err = cs.internalMount(ctx, dstVol, nil, volCap); err != nil {
+	if err = cs.internalMount(ctx, dstVol, nil, volCap, req.GetSecrets()); err != nil {
 		return status.Errorf(codes.Internal, "failed to mount dst nfs server: %v", err)
 	}
 	defer func() {

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -142,6 +142,8 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case pvcNamespaceKey:
 		case pvcNameKey:
 		case pvNameKey:
+		case paramKrbPrincipal:
+		case paramKrbPasswordSecret:
 			// no op
 		case mountPermissionsField:
 			if v != "" {

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -506,8 +506,17 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		// don't set subDir, server, or share fields: only nfs-server:/share
 		// should be mounted via the volume's own values across all internal
 		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.)
+		//
+		// Also drop mountPermissions: the internal mount is only used by the
+		// controller to MkdirAll a subdirectory under the base share. Passing
+		// mountPermissions here makes NodePublishVolume run chmod on the mount
+		// root itself, which is rejected by root_squash'd NFS servers (and by
+		// Kerberos exports where the client is authenticated as a non-owner)
+		// with EPERM even though the mount itself succeeded. The subdirectory
+		// permissions are handled separately via chmodIfPermissionMismatch on
+		// internalVolumePath in CreateVolume.
 		switch strings.ToLower(k) {
-		case paramSubDir, paramServer, paramShare:
+		case paramSubDir, paramServer, paramShare, mountPermissionsField:
 			continue
 		default:
 			volContext[k] = v

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -79,6 +79,9 @@ const (
 	paramKrbPrincipal = "authprincipal"
 	// name of a secret containing the Kerberos password to use when authenticating
 	paramKrbPasswordSecret = "authpasswordsecret"
+	// name of a secret containing the contents of a krb5.conf file with
+	// realm and/or KDC information
+	paramKrbConf          = "authkrbconf"
 	paramOnDelete          = "ondelete"
 	mountOptionsField      = "mountoptions"
 	mountPermissionsField  = "mountpermissions"

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -82,15 +82,15 @@ const (
 	// name of a secret containing the contents of a krb5.conf file with
 	// realm and/or KDC information
 	paramKrbConf          = "authkrbconf"
-	paramOnDelete          = "ondelete"
-	mountOptionsField      = "mountoptions"
-	mountPermissionsField  = "mountpermissions"
-	pvcNameKey             = "csi.storage.k8s.io/pvc/name"
-	pvcNamespaceKey        = "csi.storage.k8s.io/pvc/namespace"
-	pvNameKey              = "csi.storage.k8s.io/pv/name"
-	pvcNameMetadata        = "${pvc.metadata.name}"
-	pvcNamespaceMetadata   = "${pvc.metadata.namespace}"
-	pvNameMetadata         = "${pv.metadata.name}"
+	paramOnDelete         = "ondelete"
+	mountOptionsField     = "mountoptions"
+	mountPermissionsField = "mountpermissions"
+	pvcNameKey            = "csi.storage.k8s.io/pvc/name"
+	pvcNamespaceKey       = "csi.storage.k8s.io/pvc/namespace"
+	pvNameKey             = "csi.storage.k8s.io/pv/name"
+	pvcNameMetadata       = "${pvc.metadata.name}"
+	pvcNamespaceMetadata  = "${pvc.metadata.namespace}"
+	pvNameMetadata        = "${pv.metadata.name}"
 )
 
 func NewDriver(options *DriverOptions) *Driver {

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -73,17 +73,21 @@ const (
 	// The base directory must be a direct child of the root directory.
 	// The root directory is omitted from the string, for example:
 	//     "base" instead of "/base"
-	paramShare            = "share"
-	paramSubDir           = "subdir"
-	paramOnDelete         = "ondelete"
-	mountOptionsField     = "mountoptions"
-	mountPermissionsField = "mountpermissions"
-	pvcNameKey            = "csi.storage.k8s.io/pvc/name"
-	pvcNamespaceKey       = "csi.storage.k8s.io/pvc/namespace"
-	pvNameKey             = "csi.storage.k8s.io/pv/name"
-	pvcNameMetadata       = "${pvc.metadata.name}"
-	pvcNamespaceMetadata  = "${pvc.metadata.namespace}"
-	pvNameMetadata        = "${pv.metadata.name}"
+	paramShare  = "share"
+	paramSubDir = "subdir"
+	// Kerberos principal to use when mounting with `-o sec=krb5*`
+	paramKrbPrincipal = "authprincipal"
+	// name of a secret containing the Kerberos password to use when authenticating
+	paramKrbPasswordSecret = "authpasswordsecret"
+	paramOnDelete          = "ondelete"
+	mountOptionsField      = "mountoptions"
+	mountPermissionsField  = "mountpermissions"
+	pvcNameKey             = "csi.storage.k8s.io/pvc/name"
+	pvcNamespaceKey        = "csi.storage.k8s.io/pvc/namespace"
+	pvNameKey              = "csi.storage.k8s.io/pv/name"
+	pvcNameMetadata        = "${pvc.metadata.name}"
+	pvcNamespaceMetadata   = "${pvc.metadata.namespace}"
+	pvNameMetadata         = "${pv.metadata.name}"
 )
 
 func NewDriver(options *DriverOptions) *Driver {

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -78,7 +78,7 @@ const (
 	// Kerberos principal to use when mounting with `-o sec=krb5*`
 	paramKrbPrincipal = "authprincipal"
 	// name of a secret containing the base64-encoded Kerberos keytab to authenticate with
-	paramKrbKeytab        = "authkeytab"
+	paramKrbKeytab = "authkeytab"
 	// name of a secret containing the contents of a krb5.conf file with
 	// realm and/or KDC information
 	paramKrbConf          = "authkrbconf"

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -77,8 +77,8 @@ const (
 	paramSubDir = "subdir"
 	// Kerberos principal to use when mounting with `-o sec=krb5*`
 	paramKrbPrincipal = "authprincipal"
-	// name of a secret containing the Kerberos password to use when authenticating
-	paramKrbPasswordSecret = "authpasswordsecret"
+	// name of a secret containing the base64-encoded Kerberos keytab to authenticate with
+	paramKrbKeytab        = "authkeytab"
 	// name of a secret containing the contents of a krb5.conf file with
 	// realm and/or KDC information
 	paramKrbConf          = "authkrbconf"

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -170,7 +170,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				return err
 			}
 			// initialize credentials from keytab
-			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)	
+			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
 			if err := cmd.Run(); err != nil {
 				klog.Errorf("error running 'kinit -k': %+v", err)
 				return err

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -172,8 +172,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			// initialize credentials from keytab
 			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
 			if err := cmd.Run(); err != nil {
-				klog.Errorf("error running 'kinit -k': %+v", err)
-				return err
+				klog.Warningf("error running 'kinit -k', but soldiering on: %+v", err)
 			}
 		}
 		return ns.mounter.Mount(source, targetPath, "nfs", mountOptions)

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -158,6 +158,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				cmd := exec.CommandContext(ctx, "ktutil")
 				cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("addent -p %s -password -k 1 -f\n%s\nwkt /etc/krb5.keytab", krbPrinc, krbPwd))
 				if err := cmd.Run(); err != nil {
+					klog.Errorf("error running 'ktutil': %+v", err)
 					return err
 				}
 			}
@@ -165,15 +166,13 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			cmd := exec.CommandContext(ctx, "kinit", krbPrinc)
 			cmd.Stdin = bytes.NewBufferString(krbPwd + "\n")
 			if err := cmd.Run(); err != nil {
+				klog.Errorf("error running 'kinit': %+v", err)
 				return err
 			}
 			// initialize credentials from keytab
-			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
-			if err != nil {
-				return err
-			}
+			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)	
 			if err := cmd.Run(); err != nil {
-				klog.Errorf("%+v", err)
+				klog.Errorf("error running 'kinit -k': %+v", err)
 				return err
 			}
 		}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -142,7 +142,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if !notMnt {
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
-	
+
 	if krbConf != "" {
 		os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775)
 	}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -68,6 +68,7 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	}
 
 	var server, baseDir, subDir string
+	var krbPwd, krbPrinc string
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
@@ -79,6 +80,12 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 			baseDir = v
 		case paramSubDir:
 			subDir = v
+		case paramKrbPrincipal:
+			krbPrinc = v
+		case paramKrbPasswordSecret:
+			if v != "" {
+				krbPwd = req.GetSecrets()[v]
+			}
 		case pvcNamespaceKey:
 			subDirReplaceMap[pvcNamespaceMetadata] = v
 		case pvcNameKey:

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -167,7 +167,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			}
 			// initialize credentials from keytab
 			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
-			stderr, err := cmd.StderrPipe()
 			if err != nil {
 				return err
 			}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -144,7 +144,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	if krbConf != "" {
-		os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775)
+		if err = os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
 	execFunc := func() error {

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -42,7 +42,7 @@ type NodeServer struct {
 }
 
 // NodePublishVolume mount the volume
-func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	volCap := req.GetVolumeCapability()
 	if volCap == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability missing in request")

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -47,7 +47,7 @@ type NodeServer struct {
 }
 
 // NodePublishVolume mount the volume
-func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	volCap := req.GetVolumeCapability()
 	if volCap == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume capability missing in request")

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -159,6 +160,34 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
 	execFunc := func() error {
+		if krbPrinc != "" && krbPwd != "" {
+			klog.V(3).Infof("Setting up kerberos auth with principal '%s' and password '%s'", krbPrinc, krbPwd)
+			_, err := os.Stat("/etc/krb5.keytab")
+			// initialize keytab if it doesn't exist
+			if err != nil && os.IsNotExist(err) {
+				cmd := exec.CommandContext(ctx, "ktutil")
+				cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("addent -p %s -password -k 1 -f\n%s\nwkt /etc/krb5.keytab", krbPrinc, krbPwd))
+				if err := cmd.Run(); err != nil {
+					return err
+				}
+			}
+			// obtain kerberos TGT
+			cmd := exec.CommandContext(ctx, "kinit", krbPrinc)
+			cmd.Stdin = bytes.NewBufferString(krbPwd + "\n")
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			// initialize credentials from keytab
+			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
+			stderr, err := cmd.StderrPipe()
+			if err != nil {
+				return err
+			}
+			if err := cmd.Run(); err != nil {
+				klog.Errorf("%+v", err)
+				return err
+			}
+		}
 		return ns.mounter.Mount(source, targetPath, "nfs", mountOptions)
 	}
 	timeoutFunc := func() error {

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nfs
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -217,12 +218,35 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			}
 			// give the kernel a moment to notice the old gssd is gone
 			time.Sleep(500 * time.Millisecond)
-			gssdCmd := exec.Command("/usr/sbin/rpc.gssd", "-vvv")
+			// -vvv: verbose, -f: foreground (so we can capture output),
+			// -D: don't require reverse-DNS canonicalization of target NFS server
+			// (kube-dns generally does not serve PTR records for Service IPs, and
+			// the default gssd behavior is to canonicalize the mount target's
+			// hostname before building the SPN, which then fails to match the
+			// nfs/<svc-fqdn>@REALM entry in our keytab and hangs the upcall).
+			gssdCmd := exec.Command("/usr/sbin/rpc.gssd", "-vvv", "-f", "-D")
+			var gssdOut lockedBuffer
+			gssdCmd.Stdout = &gssdOut
+			gssdCmd.Stderr = &gssdOut
 			if err := gssdCmd.Start(); err != nil {
 				klog.Errorf("failed to (re)start rpc.gssd: %v", err)
 				return err
 			}
-			klog.V(3).Infof("(re)started rpc.gssd pid=%d", gssdCmd.Process.Pid)
+			klog.V(3).Infof("(re)started rpc.gssd pid=%d args=%v", gssdCmd.Process.Pid, gssdCmd.Args)
+			// Drain rpc.gssd output into klog so failures are diagnosable instead
+			// of the current silent 110s mount timeout.
+			go func(pid int) {
+				t := time.NewTicker(2 * time.Second)
+				defer t.Stop()
+				for range t.C {
+					if s := gssdOut.drain(); s != "" {
+						klog.V(3).Infof("rpc.gssd pid=%d: %s", pid, s)
+					}
+					if gssdCmd.ProcessState != nil {
+						return
+					}
+				}
+			}(gssdCmd.Process.Pid)
 			// give rpc.gssd a beat to open its rpc_pipefs watches before the mount
 			time.Sleep(1 * time.Second)
 		}
@@ -416,4 +440,26 @@ func isStaleFileHandle(err error) bool {
 		return errno == syscall.ESTALE
 	}
 	return strings.Contains(err.Error(), "stale NFS file handle") || strings.Contains(err.Error(), "stale file handle")
+}
+
+// lockedBuffer is a bytes.Buffer safe for concurrent Write() from a subprocess
+// pipe reader and drain() reads from a klog forwarder goroutine.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+// drain returns and clears the currently buffered bytes as a string.
+func (b *lockedBuffer) drain() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := b.buf.String()
+	b.buf.Reset()
+	return s
 }

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -161,7 +161,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 	}
-	
+
 	if krbConf != "" {
 		os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775)
 	}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -19,6 +19,7 @@ package nfs
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -76,7 +77,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	var server, baseDir, subDir string
-	var krbPwd, krbPrinc, krbConf string
+	var encodedKrbKeytab, krbPrinc, krbConf string
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
@@ -90,9 +91,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			subDir = v
 		case paramKrbPrincipal:
 			krbPrinc = v
-		case paramKrbPasswordSecret:
+		case paramKrbKeytab:
 			if v != "" {
-				krbPwd = req.GetSecrets()[v]
+				encodedKrbKeytab = req.GetSecrets()[v]
 			}
 		case paramKrbConf:
 			if v != "" {
@@ -169,38 +170,34 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 	}
+
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
 	execFunc := func() error {
-		if krbPrinc != "" && krbPwd != "" {
-			klog.V(3).Infof("Setting up kerberos auth with principal '%s' and password '%s'", krbPrinc, krbPwd)
-			_, err := os.Stat("/etc/krb5.keytab")
-			// initialize keytab if it doesn't exist
-			if err != nil && os.IsNotExist(err) {
-				cmd := exec.CommandContext(ctx, "ktutil")
-				cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("addent -p %s -password -k 1 -f\n%s\nwkt /etc/krb5.keytab", krbPrinc, krbPwd))
-				var ktOut bytes.Buffer
-				cmd.Stdout = &ktOut
-				cmd.Stderr = &ktOut
-				if err := cmd.Run(); err != nil {
-					klog.Errorf("error running 'ktutil': %+v, output=%q", err, ktOut.String())
-					return err
-				}
-				klog.V(3).Infof("ktutil output: %s", ktOut.String())
-			}
-			// obtain kerberos TGT
-			cmd := exec.CommandContext(ctx, "kinit", krbPrinc)
-			cmd.Stdin = bytes.NewBufferString(krbPwd + "\n")
-			var kinitOut bytes.Buffer
-			cmd.Stdout = &kinitOut
-			cmd.Stderr = &kinitOut
-			if err := cmd.Run(); err != nil {
-				klog.Errorf("error running 'kinit': %+v, output=%q", err, kinitOut.String())
+		var (
+			keytab []byte
+			err    error
+		)
+		if encodedKrbKeytab != "" {
+			keytab, err = base64.StdEncoding.DecodeString(encodedKrbKeytab)
+			if err != nil {
+				klog.Errorf("error while decoding keytab: %v", err)
 				return err
 			}
-			klog.V(3).Infof("kinit (password) output: %s", kinitOut.String())
+		}
+		if len(keytab) > 0 {
+			err = os.WriteFile("/etc/krb5.keytab", keytab, 0600)
+			if err != nil {
+				klog.Errorf("error while writing decoded keytab: %v", err)
+				return err
+			}
+		}
+
+		if krbPrinc != "" {
+			klog.V(3).Infof("Setting up kerberos auth with principal '%s'", krbPrinc)
+			var kinitOut bytes.Buffer
 			// initialize credentials from keytab
 			kinitOut.Reset()
-			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
+			cmd := exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
 			cmd.Stdout = &kinitOut
 			cmd.Stderr = &kinitOut
 			if err := cmd.Run(); err != nil {

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -177,23 +177,54 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			if err != nil && os.IsNotExist(err) {
 				cmd := exec.CommandContext(ctx, "ktutil")
 				cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("addent -p %s -password -k 1 -f\n%s\nwkt /etc/krb5.keytab", krbPrinc, krbPwd))
+				var ktOut bytes.Buffer
+				cmd.Stdout = &ktOut
+				cmd.Stderr = &ktOut
 				if err := cmd.Run(); err != nil {
-					klog.Errorf("error running 'ktutil': %+v", err)
+					klog.Errorf("error running 'ktutil': %+v, output=%q", err, ktOut.String())
 					return err
 				}
+				klog.V(3).Infof("ktutil output: %s", ktOut.String())
 			}
 			// obtain kerberos TGT
 			cmd := exec.CommandContext(ctx, "kinit", krbPrinc)
 			cmd.Stdin = bytes.NewBufferString(krbPwd + "\n")
+			var kinitOut bytes.Buffer
+			cmd.Stdout = &kinitOut
+			cmd.Stderr = &kinitOut
 			if err := cmd.Run(); err != nil {
-				klog.Errorf("error running 'kinit': %+v", err)
+				klog.Errorf("error running 'kinit': %+v, output=%q", err, kinitOut.String())
 				return err
 			}
+			klog.V(3).Infof("kinit (password) output: %s", kinitOut.String())
 			// initialize credentials from keytab
+			kinitOut.Reset()
 			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
+			cmd.Stdout = &kinitOut
+			cmd.Stderr = &kinitOut
 			if err := cmd.Run(); err != nil {
-				klog.Warningf("error running 'kinit -k', but soldiering on: %+v", err)
+				klog.Warningf("error running 'kinit -k', but soldiering on: %+v, output=%q", err, kinitOut.String())
+			} else {
+				klog.V(3).Infof("kinit -k output: %s", kinitOut.String())
 			}
+			// Restart rpc.gssd so it picks up the freshly-written /etc/krb5.conf
+			// and /etc/krb5.keytab. rpc.gssd was started at container init before
+			// these files existed, and it does not re-read them on its own.
+			// Without a restart the kernel GSS upcall for sec=krb5 hangs and the
+			// mount(2) call times out after 110s.
+			if out, err := exec.CommandContext(ctx, "pkill", "-x", "rpc.gssd").CombinedOutput(); err != nil {
+				klog.V(3).Infof("pkill rpc.gssd: err=%v output=%q (ok if not previously running)", err, string(out))
+			}
+			// give the kernel a moment to notice the old gssd is gone
+			time.Sleep(500 * time.Millisecond)
+			gssdCmd := exec.Command("/usr/sbin/rpc.gssd", "-vvv")
+			if err := gssdCmd.Start(); err != nil {
+				klog.Errorf("failed to (re)start rpc.gssd: %v", err)
+				return err
+			}
+			klog.V(3).Infof("(re)started rpc.gssd pid=%d", gssdCmd.Process.Pid)
+			// give rpc.gssd a beat to open its rpc_pipefs watches before the mount
+			time.Sleep(1 * time.Second)
 		}
 		return ns.mounter.Mount(source, targetPath, "nfs", mountOptions)
 	}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -189,7 +189,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				return err
 			}
 			// initialize credentials from keytab
-			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)	
+			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
 			if err := cmd.Run(); err != nil {
 				klog.Errorf("error running 'kinit -k': %+v", err)
 				return err

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -74,7 +74,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	var server, baseDir, subDir string
-	var krbPwd, krbPrinc string
+	var krbPwd, krbPrinc, krbConf string
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
@@ -91,6 +91,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		case paramKrbPasswordSecret:
 			if v != "" {
 				krbPwd = req.GetSecrets()[v]
+			}
+		case paramKrbConf:
+			if v != "" {
+				krbConf = req.GetSecrets()[v]
 			}
 		case pvcNamespaceKey:
 			subDirReplaceMap[pvcNamespaceMetadata] = v
@@ -157,7 +161,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 	}
-
+	
+	if krbConf != "" {
+		os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775)
+	}
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
 	execFunc := func() error {
 		if krbPrinc != "" && krbPwd != "" {

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -191,8 +191,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			// initialize credentials from keytab
 			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
 			if err := cmd.Run(); err != nil {
-				klog.Errorf("error running 'kinit -k': %+v", err)
-				return err
+				klog.Warningf("error running 'kinit -k', but soldiering on: %+v", err)
 			}
 		}
 		return ns.mounter.Mount(source, targetPath, "nfs", mountOptions)

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -177,6 +177,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 				cmd := exec.CommandContext(ctx, "ktutil")
 				cmd.Stdin = bytes.NewBufferString(fmt.Sprintf("addent -p %s -password -k 1 -f\n%s\nwkt /etc/krb5.keytab", krbPrinc, krbPwd))
 				if err := cmd.Run(); err != nil {
+					klog.Errorf("error running 'ktutil': %+v", err)
 					return err
 				}
 			}
@@ -184,15 +185,13 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			cmd := exec.CommandContext(ctx, "kinit", krbPrinc)
 			cmd.Stdin = bytes.NewBufferString(krbPwd + "\n")
 			if err := cmd.Run(); err != nil {
+				klog.Errorf("error running 'kinit': %+v", err)
 				return err
 			}
 			// initialize credentials from keytab
-			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
-			if err != nil {
-				return err
-			}
+			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)	
 			if err := cmd.Run(); err != nil {
-				klog.Errorf("%+v", err)
+				klog.Errorf("error running 'kinit -k': %+v", err)
 				return err
 			}
 		}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -73,6 +73,7 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	}
 
 	var server, baseDir, subDir string
+	var krbPwd, krbPrinc string
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
@@ -84,6 +85,12 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 			baseDir = v
 		case paramSubDir:
 			subDir = v
+		case paramKrbPrincipal:
+			krbPrinc = v
+		case paramKrbPasswordSecret:
+			if v != "" {
+				krbPwd = req.GetSecrets()[v]
+			}
 		case pvcNamespaceKey:
 			subDirReplaceMap[pvcNamespaceMetadata] = v
 		case pvcNameKey:

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -186,7 +186,6 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			}
 			// initialize credentials from keytab
 			cmd = exec.CommandContext(ctx, "kinit", "-k", krbPrinc)
-			stderr, err := cmd.StderrPipe()
 			if err != nil {
 				return err
 			}

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -163,7 +163,9 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	if krbConf != "" {
-		os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775)
+		if err = os.WriteFile("/etc/krb5.conf", []byte(krbConf), 0775); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
 	execFunc := func() error {

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -192,7 +192,7 @@ func chmodIfPermissionMismatch(targetPath string, mode uint32) error {
 	mask := os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky
 	currentMode := info.Mode() & mask
 	if currentMode != desiredMode {
-		klog.V(2).Infof("chmod targetPath(%s, currentMode:0%o) with desiredMode(0%o)", targetPath, mode, mode)
+		klog.V(2).Infof("chmod targetPath(%s, currentMode:0%o) with desiredMode(0%o)", targetPath, uint32(currentMode.Perm()|currentMode&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky)), mode)
 		if err := chmod(targetPath, mode); err != nil {
 			return err
 		}

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -52,6 +52,29 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 	})
 
 	testDriver = driver.InitNFSDriver()
+	ginkgo.It("should create a volume with kerberos auth", func(ctx ginkgo.SpecContext) {
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "1Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+						MountOptions: []string{"sec=krb5", "noresvport", "nfsvers=4"},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedVolumeWithKerberosAuth{
+			Pods:                   pods,
+			StorageClassParameters: krbStorageClassParameters,
+			Driver:                 testDriver,
+		}
+		test.Run(ctx, cs, ns)
+	})
 	ginkgo.It("should create a volume on demand with mount options", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
 						},
-						MountOptions: []string{"sec=krb5", "noresvport", "nfsvers=4"},
+						MountOptions: []string{"sec=krb5", "noresvport", "nfsvers=4.1"},
 					},
 				},
 			},

--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
 						},
-						MountOptions: []string{"sec=krb5", "noresvport", "nfsvers=4.1"},
+						MountOptions: []string{"sec=krb5", "nfsvers=4.1"},
 					},
 				},
 			},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -92,6 +92,16 @@ var (
 		"mountPermissions": "0755",
 		"onDelete":         "archive",
 	}
+	krbStorageClassParameters = map[string]string{
+		"server": "nfs-krb-server.default.svc.cluster.local",
+		"share":  "/srv/shared",
+		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
+		"mountPermissions":   "0755",
+		"authPasswordSecret": "krb-pwd",
+		"authPrincipal":      "nfs/nfs-krb-server.default.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
+	}
+
 	controllerServer *nfs.ControllerServer
 )
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -98,6 +98,7 @@ var (
 		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
 		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
 		"mountPermissions":   "0755",
+		"authKrbConf":        "krb5.conf",
 		"authPasswordSecret": "krb-pwd",
 		"authPrincipal":      "nfs/nfs-krb-server.default.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -108,7 +108,7 @@ var (
 		"mountPermissions":   "0755",
 		"authKrbConf":        "krb5.conf",
 		"authPasswordSecret": "krb-pwd",
-		"authPrincipal":      "nfs/nfs-krb-server.default.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
+		"authPrincipal":      "nfs/csi-nfs-client.default.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
 	}
 
 	controllerServer *nfs.ControllerServer

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -105,10 +105,10 @@ var (
 		// immediately with EINVAL ("an incorrect mount option was specified").
 		"csi.storage.k8s.io/node-publish-secret-namespace": "default",
 		"csi.storage.k8s.io/node-publish-secret-name":      "mount-options",
-		"mountPermissions":   "0755",
-		"authKrbConf":        "krb5.conf",
-		"authPasswordSecret": "krb-pwd",
-		"authPrincipal":      "nfs/csi-nfs-client.default.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
+		"mountPermissions": "0755",
+		"authKrbConf":      "krb5.conf",
+		"authKeytab":       "client.keytab.b64",
+		"authPrincipal":    "host/csi-nfs-controller.kube-system.svc.cluster.local@NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL",
 	}
 
 	controllerServer *nfs.ControllerServer

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -95,8 +95,16 @@ var (
 	krbStorageClassParameters = map[string]string{
 		"server": "nfs-krb-server.default.svc.cluster.local",
 		"share":  "/srv/shared",
-		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
-		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
+		"csi.storage.k8s.io/provisioner-secret-namespace":   "default",
+		"csi.storage.k8s.io/provisioner-secret-name":        "mount-options",
+		// Kerberos auth requires the driver to read the krb5 password + krb5.conf
+		// from a CSI secret on both the controller (CreateVolume) and the node
+		// (NodePublishVolume) code paths. Without the node-publish-secret-* keys
+		// below, req.GetSecrets() is empty on the node, so the driver skips the
+		// kinit + rpc.gssd bring-up block and mount(2) with sec=krb5 fails
+		// immediately with EINVAL ("an incorrect mount option was specified").
+		"csi.storage.k8s.io/node-publish-secret-namespace": "default",
+		"csi.storage.k8s.io/node-publish-secret-name":      "mount-options",
 		"mountPermissions":   "0755",
 		"authKrbConf":        "krb5.conf",
 		"authPasswordSecret": "krb-pwd",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -95,8 +95,8 @@ var (
 	krbStorageClassParameters = map[string]string{
 		"server": "nfs-krb-server.default.svc.cluster.local",
 		"share":  "/srv/shared",
-		"csi.storage.k8s.io/provisioner-secret-namespace":   "default",
-		"csi.storage.k8s.io/provisioner-secret-name":        "mount-options",
+		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
+		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
 		// Kerberos auth requires the driver to read the krb5 password + krb5.conf
 		// from a CSI secret on both the controller (CreateVolume) and the node
 		// (NodePublishVolume) code paths. Without the node-publish-secret-* keys

--- a/test/e2e/testsuites/dynamically_provisioned_krb_auth_volume.go
+++ b/test/e2e/testsuites/dynamically_provisioned_krb_auth_volume.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+
+	"github.com/kubernetes-csi/csi-driver-nfs/test/e2e/driver"
+	"github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type DynamicallyProvisionedVolumeWithKerberosAuth struct {
+	Driver                 driver.DynamicPVTestDriver
+	Pods                   []PodDetails
+	StorageClassParameters map[string]string
+}
+
+func (t *DynamicallyProvisionedVolumeWithKerberosAuth) Run(ctx context.Context, client clientset.Interface, namespace *v1.Namespace) {
+	for _, pod := range t.Pods {
+		tpod, cleanup := pod.SetupWithDynamicVolumes(ctx, client, namespace, t.Driver, t.StorageClassParameters)
+		for i := range cleanup {
+			defer cleanup[i](ctx)
+		}
+		ginkgo.By("deploying the pod")
+		tpod.Create(ctx)
+		defer tpod.Cleanup(ctx)
+		ginkgo.By("checking that the pods command exits with no error")
+		tpod.WaitForSuccess(ctx)
+	}
+}

--- a/test/krb5.conf
+++ b/test/krb5.conf
@@ -1,0 +1,13 @@
+[libdefaults]
+default_realm = NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
+
+[realms]
+NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL = {
+	tkdc = nfs-krb-server.default.svc.cluster.local
+	tadmin_server = nfs-krb-server.default.svc.cluster.local
+}
+
+[logging]
+kdc = FILE:/var/log/krb5kdc.log
+admin_server = FILE:/var/log/kadmin.log
+default = FILE:/var/log/krb5lib.log

--- a/test/krb5.conf
+++ b/test/krb5.conf
@@ -3,8 +3,8 @@ default_realm = NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL
 
 [realms]
 NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL = {
-	tkdc = nfs-krb-server.default.svc.cluster.local
-	tadmin_server = nfs-krb-server.default.svc.cluster.local
+	kdc = nfs-krb-server.default.svc.cluster.local
+	admin_server = nfs-krb-server.default.svc.cluster.local
 }
 
 [logging]

--- a/test/utils/setup-krb.sh
+++ b/test/utils/setup-krb.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl -n default create secret generic mount-options \
+  --from-literal=mountOptions='nfsvers=4.1' \
+  --from-literal=krb-pwd='password!' \
+  --dry-run=client -o yaml |
+kubectl apply -f -
+
+kubectl apply -f deploy/example/nfs-provisioner/nfs-server.yaml
+kubectl apply -f deploy/example/nfs-provisioner/nfs-krb-server.yaml
+
+kubectl -n default rollout status deployment/nfs-krb-server \
+  --timeout=120s
+
+server_pod="$(
+  kubectl -n default get pod \
+    -l app=nfs-krb-server \
+    -o jsonpath='{.items[0].metadata.name}'
+)"
+
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+kubectl -n default exec "$server_pod" -- \
+  cat /shared/krb5.conf >"$test_dir/krb5.conf"
+
+kubectl -n default exec "$server_pod" -- \
+  cat /shared/client.keytab >"$test_dir/client.keytab"
+
+# CSI secrets are map<string,string>. Encode the binary keytab explicitly
+# so it remains valid text while passing through CSI.
+base64 -w0 "$test_dir/client.keytab" >"$test_dir/client.keytab.b64"
+
+kubectl -n default create secret generic mount-options \
+  --from-literal=mountOptions='nfsvers=4.1' \
+  --from-literal=krb-pwd='password!' \
+  --from-file=krb5.conf="$test_dir/krb5.conf" \
+  --from-file=client.keytab.b64="$test_dir/client.keytab.b64" \
+  --dry-run=client -o yaml |
+kubectl apply -f -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR implements authentication with a kerberos principal and password when mounting NFS shares.

**Which issue(s) this PR fixes**:

Fixes #525

**Special notes for your reviewer**:
- **I changed the Dockerfile's base image to `debian:stable-slim`**
  Justification: services cannot be started due to a missing file `/lib/lsb/init-functions`
- **I changed the Dockerfile's entrypoint to a script (`entry.sh`)**
  The script is created in the Dockerfile inline, and you can review it [here](https://github.com/GamerGirlandCo/csi-driver-nfs/blob/21956ed61da89132c94d1192a00fa25562fc2c6b/Dockerfile#L32-L41)
  Justification: this is so we can start necessary services (`rpcbind` and `nfs-common`) if and only if we're in the controller pod. Otherwise, the `nfsplugin` binary is invoked with the exact same arguments the pod's `nfs` container was started with.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added the ability to authenticate with kerberos-protected NFS shares
The following new parameters may be specified when creating or updating a storage class:
- **`authPrincipal`**
  The principal that will be used to authenticate to the share
- **`authKeytab`**
  The secret containing base64-encoded keytab content
- **`authKrbConf`**
  The secret containing contents of a krb5.conf with information about how to connect to a realm.
```



---

## Investigation update (2026-08-18) — Kerberos e2e mount timeout

CI job `pull-csi-driver-nfs-e2e-capz` run [`2089605852326531072`](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-csi_csi-driver-nfs/999/pull-csi-driver-nfs-e2e-capz/2089605852326531072) — the Kerberos mount `mount.nfs4 -o sec=krb5,vers=4.1 nfs-krb-server.default.svc.cluster.local:/srv/shared` hangs 110s and fails with `mount.nfs4: Connection timed out`.

### Debug artifacts pulled
- Client side (controller pod): [`csi-nfs-controller-*/nfs.log`](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-csi_csi-driver-nfs/999/pull-csi-driver-nfs-e2e-capz/2089605852326531072/artifacts/clusters/capz-9j4atl/kube-system/) — `rpc.gssd -vf` shows two successful `do_downcall` with 24h lifetime, so client-side GSS init is fine.
- Server side (`nfs-krb-server-7cd8697649-lkjxj/nfs-krb-server.log`) — KDC + mountd + tail of `/var/log/rpc-gssd.log`; **`/var/log/gssd.log` (rpc.svcgssd verbose log) is empty for the whole test window**.

### Timeline (server-side, 07:18–07:20 UTC)
- `07:18:57` KDC `AS_REQ ISSUE` — kinit for `nfs/nfs-krb-server...` (password auth)
- `07:18:58` `AS_REQ ISSUE` — kinit `-k` from keytab
- `07:19:02` `AS_REQ ISSUE` — rpc.gssd machine credential
- `07:19:03` `TGS_REQ ISSUE` — `nfs/nfs-krb-server...` requests service ticket for **itself** (only principal in the KDC)
- `07:19:03` `rpc.mountd: successful authentication for IP 192.168.163.0 as *` → wildcard export accepted
- **Then silence for 90+ seconds until `mount.nfs4` gives up.**
- No entry in `rpc-gssd.log` / `gssd.log` from svcgssd → **kernel nfsd never up-called svcgssd for context verification**.

### Root-cause candidates on the server image (`thealmightydrawingtablet/nfs-krb:alpine`)
Extracted `entry.sh`/`init.sh` from the image confirm:

1. **KDC only ever provisions one principal**: `nfs/nfs-krb-server.default.svc.cluster.local`. There is no separate `host/…` or client user principal. The client's `rpc.gssd` reuses this principal as a machine cred → server receives context where `client == server`, `svcgssd` silently drops it.
2. **`sec=krb5p:krb5i:krb5` in exports with `krb5p` first**: negotiation may fail against the client mount opt `sec=krb5` (integrity only) on some kernels; there is no `sec=sys` fallback for v4.1 SEQUENCE.
3. **idmapd `Domain` is set to the realm string** `NFS-KRB-SERVER.DEFAULT.SVC.CLUSTER.LOCAL` (not a DNS-style domain) — this is known to stall NFSv4 `PUTROOTFH`/`GETATTR` when nfsd tries to id-map the caller.
4. `entry.sh` restarts `rpc.svcgssd` manually after start (`pidof rpc.svcgssd` loop), suggesting the packaged init already had issues.
5. Sanity: from the **same** controller pod a plain `sec=sys` mount of an unrelated `nfs-server` succeeded, so networking / DNS / RPC portmap are all healthy — problem is 100% inside the krb5 code path.

### What is NOT the problem (previously ruled out)
- `noresvport`: controller runs with `hostNetwork+privileged+SYS_ADMIN`, server exports have `insecure`. Removing `noresvport` did not change the outcome.
- Client-side GSS init: `do_downcall` succeeds twice with normal lifetime.
- Plain NFS mount from the same client pod: works, so no CNI/DNS/portmap regression.

### Proposal
The image / yaml under `test/nfs-krb-server/` needs at least (any one of these is likely enough):
- Provision a **separate host/machine principal** for the client and mount its keytab into the controller pod, OR
- Simplify export sec list to just `sec=krb5` and add `sec=sys` fallback so v4.1 session bring-up doesn't hinge on GSS, OR
- Fix `/etc/idmapd.conf` `Domain=` to a DNS name and align `Local-Realms`.

Until the server image is fixed, we can:
- **`ginkgo.Skip`** the Kerberos e2e case (label `[Kerberos]`) so this PR can proceed on its non-Kerberos merits (rpc.gssd lifecycle, secret plumbing, mountPermissions), OR
- Split the server fix into a follow-up PR and gate the e2e on that image tag.

/cc @andyzhangx
