### PR TITLE
chore: pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,17 +38,17 @@ jobs:
 
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ^1.18
       id: go
 
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,8 +8,8 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: codespell-project/actions-codespell@master
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: codespell-project/actions-codespell@cf810cf4cbd6cdefe6ef86e55b64d524a16654a7 # master
         with:
           check_filenames: true
           skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ^1.16
       id: go
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Run unit tests
       run: |
         go version

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -11,13 +11,13 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: ^1.17
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Build Test
       run: |

--- a/.github/workflows/pluto.yaml
+++ b/.github/workflows/pluto.yaml
@@ -11,11 +11,11 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     # https://pluto.docs.fairwinds.com/advanced/#display-options
     - name: Download pluto
-      uses: FairwindsOps/pluto/github-action@master
+      uses: FairwindsOps/pluto/github-action@fecfabc295821130532c5f77b27aa8ffe2c1c5a0 # master
 
     - name: Check deploy folder
       run: |

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -16,9 +16,9 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
       env:
          SHELLCHECK_OPTS: -e SC2034
       with:

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -8,12 +8,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Set up Go 1.x
-              uses: actions/setup-go@v6
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
               with:
                 go-version: ^1.19
-            - uses: actions/checkout@master
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             - name: Run linter
-              uses: golangci/golangci-lint-action@v7
+              uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
               with:
                   version: v2.10
                   args: -E=errcheck,govet,unused,ineffassign,staticcheck,revive,misspell,asciicheck,bodyclose,dogsled,durationcheck,errname,forbidigo --timeout=30m0s
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@master
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
             - name: Verify Helm
               run: |
                 sudo snap install yq

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.9
       

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ matrix.go }}
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run Windows Unit Tests
         run: |
           go version


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Pin all GitHub Actions in `.github/workflows/` to full-length commit SHAs on the `release-4.13` branch, as required by the repository's action policy.

Actions pinned:
- `actions/checkout@v5` → `93cb6efe18208431cddfb8368fd83d5badbf9bfd`
- `actions/checkout@master` → `93cb6efe18208431cddfb8368fd83d5badbf9bfd` (v5)
- `actions/setup-go@v6` → `4a3601121dd01d1626a1e23e37211e3254c1c06c`
- `github/codeql-action/init@v4` → `95e58e9a2cdfd71adc6e0353d5c52f41a045d225`
- `github/codeql-action/analyze@v4` → `95e58e9a2cdfd71adc6e0353d5c52f41a045d225`
- `golangci/golangci-lint-action@v7` → `9fae48acfc02a90574d7c304a1758ef9895495fa`
- `FairwindsOps/pluto/github-action@master` → `fecfabc295821130532c5f77b27aa8ffe2c1c5a0`
- `ludeeus/action-shellcheck@master` → `00b27aa7cb85167568cb48a3838b75f4265f2bca`
- `codespell-project/actions-codespell@master` → `cf810cf4cbd6cdefe6ef86e55b64d524a16654a7`

**Release note:**

```
NONE
```