### PR TITLE
fix: detect and remount stale NFS mounts in NodePublishVolume

### DIFF
--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -18,10 +18,12 @@ package nfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -131,7 +133,18 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 		}
 	}
 	if !notMnt {
-		return &csi.NodePublishVolumeResponse{}, nil
+		// check if the existing mount is stale (e.g. after NFS server restart)
+		if _, err := os.Lstat(targetPath); err != nil && os.IsPermission(err) {
+			return &csi.NodePublishVolumeResponse{}, nil
+		} else if err != nil && isStaleFileHandle(err) {
+			klog.Warningf("NodePublishVolume: detected stale mount at %s, attempting remount", targetPath)
+			if unmountErr := ns.mounter.Unmount(targetPath); unmountErr != nil {
+				return nil, status.Errorf(codes.Internal, "failed to unmount stale mount %s: %v", targetPath, unmountErr)
+			}
+			// fall through to remount
+		} else {
+			return &csi.NodePublishVolumeResponse{}, nil
+		}
 	}
 
 	klog.V(2).Infof("NodePublishVolume: volumeID(%v) source(%s) targetPath(%s) mountflags(%v)", volumeID, source, targetPath, mountOptions)
@@ -314,4 +327,16 @@ func makeDir(pathname string) error {
 		}
 	}
 	return nil
+}
+
+// isStaleFileHandle checks if an error is caused by a stale NFS file handle (ESTALE)
+func isStaleFileHandle(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ESTALE
+	}
+	return strings.Contains(err.Error(), "stale NFS file handle") || strings.Contains(err.Error(), "stale file handle")
 }

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -36,6 +36,9 @@ import (
 
 const mountTimeoutInSec = 110
 
+// lstatFunc is used for testing to inject stale file handle errors
+var lstatFunc = os.Lstat
+
 // NodeServer driver
 type NodeServer struct {
 	Driver  *Driver
@@ -134,7 +137,7 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	}
 	if !notMnt {
 		// check if the existing mount is stale (e.g. after NFS server restart)
-		if _, err := os.Lstat(targetPath); err != nil && os.IsPermission(err) {
+		if _, err := lstatFunc(targetPath); err != nil && os.IsPermission(err) {
 			return &csi.NodePublishVolumeResponse{}, nil
 		} else if err != nil && isStaleFileHandle(err) {
 			klog.Warningf("NodePublishVolume: detected stale mount at %s, attempting remount", targetPath)

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -177,6 +178,24 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetTest,
 				Readonly:         true},
 			expectedErr: status.Error(codes.InvalidArgument, "invalid mountPermissions 07ab"),
+		},
+		{
+			desc: "[Success] Stale mount detected and remounted",
+			setup: func() {
+				lstatFunc = func(name string) (os.FileInfo, error) {
+					return nil, syscall.ESTALE
+				}
+			},
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    params,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       alreadyMountedTarget,
+				Readonly:         true},
+			expectedErr: nil,
+			cleanup: func() {
+				lstatFunc = os.Lstat
+			},
 		},
 	}
 
@@ -371,4 +390,26 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	// Clean up
 	err = os.RemoveAll(fakePath)
 	assert.NoError(t, err)
+}
+
+func TestIsStaleFileHandle(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"ESTALE errno", syscall.ESTALE, true},
+		{"other errno", syscall.ENOENT, false},
+		{"stale NFS file handle string", fmt.Errorf("stale NFS file handle"), true},
+		{"stale file handle string", fmt.Errorf("stale file handle"), true},
+		{"unrelated error", fmt.Errorf("something else"), false},
+		{"wrapped ESTALE", fmt.Errorf("wrap: %w", syscall.ESTALE), true},
+	}
+	for _, tc := range tests {
+		result := isStaleFileHandle(tc.err)
+		if result != tc.expected {
+			t.Errorf("isStaleFileHandle(%v): got %v, want %v", tc.desc, result, tc.expected)
+		}
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When an NFS server restarts, existing mounts on nodes become stale. If a pod with `fsGroup` is then restarted, kubelet's `applyFSGroup` calls `lstat` on the mount path and fails with `ESTALE` (stale NFS file handle) before the CSI driver gets a chance to remount.

This PR fixes `NodePublishVolume` to detect stale mounts and automatically unmount + remount them, so that kubelet's subsequent `applyFSGroup` succeeds.

**How does it work:**
1. When the target path is already mounted, do an `os.Lstat` check
2. If `ESTALE` is detected, unmount the stale mount
3. Fall through to the normal mount path for a fresh mount

**Which issue(s) this PR fixes:**
Ref https://github.com/kubernetes-csi/csi-driver-nfs/issues/927

**Does this PR introduce a user-facing change?**
```release-note
Fix stale NFS mount detection in NodePublishVolume: pods with fsGroup can now recover after NFS server restart without manual intervention.
```