### PR TITLE
doc: document SELinux virt_use_nfs requirement on RHEL-family Enforcing nodes

### DIFF
--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -41,3 +41,54 @@ kubectl exec -it csi-nfs-node-cvgbss -n kube-system -c nfs -- mount | grep nfs
 mkdir /tmp/test
 mount -v -t nfs -o ... nfs-server:/path /tmp/test
 ```
+
+### case#3: `mount.nfs: Operation not permitted` on RHEL/AlmaLinux/CentOS/Fedora/Rocky with SELinux Enforcing
+
+#### Symptom
+`CreateVolume` (controller) and/or `NodePublishVolume` (node) fail with logs like:
+
+```
+mount failed: exit status 32
+Mounting command: mount
+Mounting arguments: -t nfs -o nfsvers=4.1,... <server>:/<share> /tmp/pvc-...
+Output: mount.nfs: Operation not permitted
+```
+
+This happens **even though** the controller and node containers are configured with `privileged: true` and `capabilities.add: [SYS_ADMIN]`. The error is `EPERM` returned by the kernel `mount(2)` syscall — *not* a server-side ACL denial (which would surface as `access denied by server`).
+
+`ausearch -m AVC -ts recent` may show no audit lines, because SELinux denials inside privileged containers are not always logged.
+
+#### Cause
+On RHEL-family distributions with SELinux in `Enforcing` mode, the [`container-selinux`](https://github.com/containers/container-selinux/blob/main/container.te) policy gates the `mount(2)` syscall on NFS filesystems behind the `virt_use_nfs` boolean (default `off` on some images, including stock AlmaLinux/RHEL 10):
+
+```te
+tunable_policy(`virt_use_nfs',`
+    fs_manage_nfs_dirs(container_domain)
+    fs_manage_nfs_files(container_domain)
+    fs_mount_nfs(container_domain)
+    fs_unmount_nfs(container_domain)
+    ...
+')
+```
+
+With the boolean off, `fs_mount_nfs(container_domain)` is not granted, and the kernel returns `EPERM` regardless of capabilities held by the container.
+
+#### Fix
+Run on **every node** that runs the csi-driver-nfs controller or node plugin (in practice, every Kubernetes node, since the node plugin is a DaemonSet):
+
+```console
+sudo getsebool virt_use_nfs            # check current state
+sudo setsebool -P virt_use_nfs on      # -P = persist across reboots
+sudo getsebool virt_use_nfs            # expect: virt_use_nfs --> on
+```
+
+`setsebool -P` reloads the loaded policy at runtime — no service restart, no node reboot. Already-running pods pick up the change on their next mount attempt; the external-provisioner has built-in retry, so a stuck PVC will provision automatically within ~30s with no manual intervention.
+
+If a node is already in `Permissive` mode (`getenforce`), the boolean change is unnecessary there.
+
+#### Verify the fix
+```console
+kubectl get pvc -A                     # PVC should bind within ~30s
+kubectl logs -n kube-system <controller-pod> -c nfs --tail=20
+# expect: mount succeeds, NodePublishVolume completes
+```


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a `case#3` section to `docs/csi-debug.md` documenting that on RHEL-family distributions with SELinux in `Enforcing` mode (default on AlmaLinux, RHEL, CentOS, Fedora, Rocky), the CSI driver's `CreateVolume` and `NodePublishVolume` calls fail with `mount.nfs: Operation not permitted` unless the `virt_use_nfs` SELinux boolean is enabled on every node:

```bash
sudo setsebool -P virt_use_nfs on
```

The error is identical in shape to a server-side export ACL denial, the controller pod has `privileged: true` and `CAP_SYS_ADMIN`, and SELinux denials in privileged containers don't always emit AVC log lines — so this is hard to diagnose without already knowing the answer.

The authoritative gating policy is in [`containers/container-selinux`](https://github.com/containers/container-selinux/blob/main/container.te):

```
tunable_policy(`virt_use_nfs',`
    fs_mount_nfs(container_domain)
    fs_unmount_nfs(container_domain)
    fs_manage_nfs_dirs(container_domain)
    ...
')
```

A single docs paragraph in `csi-debug.md` should help the next operator hit this faster. Tested on AlmaLinux 10.1, kernel 6.12.0-124.49.1.el10_1.x86_64, container-selinux 2.234.2-4.el10, csi-driver-nfs v4.13.2, k3s v1.34.6+k3s1.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Docs-only change, no code or test impact.

**Does this PR introduce a user-facing change?**:

```release-note
none
```