### PR TITLE
fix: prevent liveness-probe port conflict during controller rolling update

### DIFF
--- a/deploy/csi-nfs-controller.yaml
+++ b/deploy/csi-nfs-controller.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-nfs-controller
   namespace: kube-system
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
During rolling updates, the new csi-nfs-controller pod can be scheduled on the same node as the old pod. The liveness-probe sidecar listens on localhost:29652, causing `address already in use` when two controller pods coexist on the same node.

This sets `maxSurge=0` and `maxUnavailable=1` on the controller Deployment so old pods are terminated before new ones are created, preventing the port conflict.

The controller can tolerate briefly running with one fewer replica during upgrades.

Note: The Helm chart already defaults to `Recreate` strategy which avoids this issue. This fix targets the static deploy manifests which had no explicit strategy (defaulting to RollingUpdate with maxSurge=25%).

Fixes #1133