### PR TITLE
fix: prevent VolumeSnapshotClass server/share from overriding source volume mount in CreateSnapshot

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -500,8 +500,9 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		paramShare:  sharePath,
 	}
 	for k, v := range volumeContext {
-		// don't set subDir field since only nfs-server:/share should be mounted in CreateVolume/DeleteVolume
-		// don't override server or share since they are already set from the volume being mounted
+		// don't set subDir, server, or share fields: only nfs-server:/share
+		// should be mounted via the volume's own values across all internal
+		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.)
 		switch strings.ToLower(k) {
 		case paramSubDir, paramServer, paramShare:
 			continue

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -501,7 +501,11 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 	}
 	for k, v := range volumeContext {
 		// don't set subDir field since only nfs-server:/share should be mounted in CreateVolume/DeleteVolume
-		if strings.ToLower(k) != paramSubDir {
+		// don't override server or share since they are already set from the volume being mounted
+		switch strings.ToLower(k) {
+		case paramSubDir, paramServer, paramShare:
+			continue
+		default:
 			volContext[k] = v
 		}
 	}

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1248,14 +1248,16 @@ func TestCreateSnapshotWithDifferentShareInSnapshotClass(t *testing.T) {
 		t.Fatalf("failed to create source directory: %v", err)
 	}
 	defer func() { _ = os.RemoveAll("/tmp/src-pv-cross-share") }()
+	defer func() { _ = os.RemoveAll("/tmp/snapshot-cross-share") }()
 
-	// Snapshot class parameters specify a DIFFERENT share than the source volume
+	// Snapshot class parameters specify a DIFFERENT server/share than the source volume.
+	// Note: share value omits leading '/' consistent with paramShare convention in this repo.
 	req := &csi.CreateSnapshotRequest{
 		SourceVolumeId: "nfs-server.default.svc.cluster.local#share#subdir#src-pv-cross-share",
 		Name:           "snapshot-cross-share",
 		Parameters: map[string]string{
 			"server": "other-nfs-server.default.svc.cluster.local",
-			"share":  "/different-share",
+			"share":  "different-share",
 		},
 	}
 
@@ -1274,8 +1276,40 @@ func TestCreateSnapshotWithDifferentShareInSnapshotClass(t *testing.T) {
 		t.Errorf("expected SourceVolumeId %q, got %q", expectedSourceVolumeID, resp.Snapshot.SourceVolumeId)
 	}
 
-	// Cleanup snapshot directory
-	_ = os.RemoveAll("/tmp/snapshot-cross-share")
+	// Verify that the FakeMounter was called with the correct mount sources:
+	// - source volume mount should use the source volume's server/share
+	// - snapshot volume mount should use the snapshot class's server/share
+	fakeMounter := cs.Driver.ns.mounter.(*mount.FakeMounter)
+	mountLog := fakeMounter.GetLog()
+
+	var foundSourceMount, foundSnapMount bool
+	for _, action := range mountLog {
+		if action.Action != "mount" {
+			continue
+		}
+		// Source volume mount: server from volumeHandle, share from volumeHandle
+		if action.Source == "nfs-server.default.svc.cluster.local:/share" {
+			foundSourceMount = true
+		}
+		// Snapshot destination mount: server/share from snapshot class parameters
+		if action.Source == "other-nfs-server.default.svc.cluster.local:/different-share" {
+			foundSnapMount = true
+		}
+	}
+	if !foundSourceMount {
+		t.Errorf("expected source volume mount with source %q, mount log: %+v",
+			"nfs-server.default.svc.cluster.local:/share", mountLog)
+	}
+	if !foundSnapMount {
+		t.Errorf("expected snapshot destination mount with source %q, mount log: %+v",
+			"other-nfs-server.default.svc.cluster.local:/different-share", mountLog)
+	}
+
+	// Verify the snapshot archive file was created
+	archivePath := "/tmp/snapshot-cross-share/snapshot-cross-share/src-pv-cross-share.tar.gz"
+	if _, err := os.Stat(archivePath); os.IsNotExist(err) {
+		t.Errorf("expected snapshot archive at %s, but it does not exist", archivePath)
+	}
 }
 
 func TestCopyVolumeFromUncompressedSnapshot(t *testing.T) {

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1288,11 +1288,13 @@ func TestCreateSnapshotWithDifferentShareInSnapshotClass(t *testing.T) {
 			continue
 		}
 		// Source volume mount: server from volumeHandle, share from volumeHandle
-		if action.Source == "nfs-server.default.svc.cluster.local:/share" {
+		// Use filepath.ToSlash to normalize Windows backslash separators
+		normalizedSource := filepath.ToSlash(action.Source)
+		if normalizedSource == "nfs-server.default.svc.cluster.local:/share" {
 			foundSourceMount = true
 		}
 		// Snapshot destination mount: server/share from snapshot class parameters
-		if action.Source == "other-nfs-server.default.svc.cluster.local:/different-share" {
+		if normalizedSource == "other-nfs-server.default.svc.cluster.local:/different-share" {
 			foundSnapMount = true
 		}
 	}

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1235,6 +1235,49 @@ func TestCreateSnapshotWithoutCompression(t *testing.T) {
 	_ = os.RemoveAll("/tmp/snapshot-name-no-compress")
 }
 
+func TestCreateSnapshotWithDifferentShareInSnapshotClass(t *testing.T) {
+	// Test that CreateSnapshot succeeds when VolumeSnapshotClass specifies
+	// a different server/share than the source volume. This verifies that
+	// the source volume mount uses server/share from the volumeHandle,
+	// not from the snapshot class parameters.
+	cs := initTestController(t)
+
+	// Setup: create source directory matching the source volume path
+	srcPath := "/tmp/src-pv-cross-share/subdir"
+	if err := os.MkdirAll(srcPath, 0777); err != nil {
+		t.Fatalf("failed to create source directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll("/tmp/src-pv-cross-share") }()
+
+	// Snapshot class parameters specify a DIFFERENT share than the source volume
+	req := &csi.CreateSnapshotRequest{
+		SourceVolumeId: "nfs-server.default.svc.cluster.local#share#subdir#src-pv-cross-share",
+		Name:           "snapshot-cross-share",
+		Parameters: map[string]string{
+			"server": "other-nfs-server.default.svc.cluster.local",
+			"share":  "/different-share",
+		},
+	}
+
+	resp, err := cs.CreateSnapshot(context.TODO(), req)
+	if err != nil {
+		t.Fatalf("CreateSnapshot failed with cross-share snapshot class: %v", err)
+	}
+
+	if resp == nil || resp.Snapshot == nil {
+		t.Fatalf("CreateSnapshot returned nil response")
+	}
+
+	// Verify the snapshot was created successfully
+	expectedSourceVolumeID := "nfs-server.default.svc.cluster.local#share#subdir#src-pv-cross-share"
+	if resp.Snapshot.SourceVolumeId != expectedSourceVolumeID {
+		t.Errorf("expected SourceVolumeId %q, got %q", expectedSourceVolumeID, resp.Snapshot.SourceVolumeId)
+	}
+
+	// Cleanup snapshot directory
+	_ = os.RemoveAll("/tmp/snapshot-cross-share")
+}
+
 func TestCopyVolumeFromUncompressedSnapshot(t *testing.T) {
 	// Create an uncompressed snapshot archive and test restoration
 	srcPath := "/tmp/uncompressed-snapshot-test/uncompressed-snapshot-test"

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1256,8 +1256,8 @@ func TestCreateSnapshotWithDifferentShareInSnapshotClass(t *testing.T) {
 		SourceVolumeId: "nfs-server.default.svc.cluster.local#share#subdir#src-pv-cross-share",
 		Name:           "snapshot-cross-share",
 		Parameters: map[string]string{
-			"server": "other-nfs-server.default.svc.cluster.local",
-			"share":  "different-share",
+			paramServer: "other-nfs-server.default.svc.cluster.local",
+			paramShare:  "different-share",
 		},
 	}
 


### PR DESCRIPTION
## What this PR does

Fixes a regression where `CreateSnapshot` fails with `lstat ... no such file or directory` when the `VolumeSnapshotClass` specifies `server`/`share` parameters that differ from the source `StorageClass`.

## Root Cause

In `internalMount()`, the `volumeContext` map (which contains VolumeSnapshotClass parameters) is iterated and merged into the `volContext` used for the NFS mount. Previously, only `subDir` was excluded from this merge. This means that `server` and `share` from the VolumeSnapshotClass would **override** the correct values already set from the volume being mounted (`vol.server` and `vol.baseDir`).

When mounting the source volume for snapshotting, this caused the driver to mount the **snapshot destination** share instead of the source share, then look for the source `subDir` inside it — which doesn't exist.

## Fix

Add `paramServer` and `paramShare` to the exclusion list in the `internalMount` loop, alongside the existing `paramSubDir` exclusion. This ensures:

- The source volume is always mounted using its own server/baseDir (from `volumeHandle`)
- The snapshot destination volume is mounted using its own server/baseDir (derived from VolumeSnapshotClass parameters via `newNFSSnapshot`/`volumeFromSnapshot`)
- Other VolumeSnapshotClass parameters (like `mountOptions`) are still passed through correctly

## Regression

- **Introduced in:** v4.11.0 (PR https://github.com/kubernetes-csi/csi-driver-nfs/pull/879)
- **Works:** v4.6.0, v4.10.0
- **Broken:** v4.11.0, v4.12.0, v4.13.1, v4.13.2

## How to reproduce

1. Create a StorageClass with `server: nfs.example.com`, `share: /exports/volumes`
2. Create a PVC, bind it, write data
3. Create a VolumeSnapshotClass with `server: nfs.example.com`, `share: /exports/snapshots` (different share)
4. Create a VolumeSnapshot → fails with `lstat` error

After fix, cross-share snapshots work correctly.

Related: https://github.com/kubernetes-csi/csi-driver-nfs/issues/1130