### PR TITLE
Run Trivy scan on pull requests

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  pull_request:
 jobs:
   build:
     name: Build


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

This PR updates the Trivy vulnerability scanner workflow to run on pull requests instead of only on a daily schedule. Running Trivy on PRs ensures that vulnerability issues are caught early in the development cycle, before code is merged to master. This provides faster feedback to contributors and helps maintain security standards.

**Which issue(s) this PR fixes:**

Fixes # NA

**Does this PR introduce a user-facing change?:**

NONE