### PR TITLE
cleanup: move build constraints after copyright header to fix boilerplate check

### DIFF
--- a/pkg/nfs/chmod_unix.go
+++ b/pkg/nfs/chmod_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/nfs/chmod_unix_test.go
+++ b/pkg/nfs/chmod_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/nfs/chmod_windows.go
+++ b/pkg/nfs/chmod_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2020 The Kubernetes Authors.


### PR DESCRIPTION
## What this PR does

Moves `//go:build` and `// +build` directives **after** the copyright header in platform-specific chmod files. The Kubernetes boilerplate checker requires the copyright/license block to be the first comment in the file.

### Files fixed
- `pkg/nfs/chmod_unix.go`
- `pkg/nfs/chmod_unix_test.go`
- `pkg/nfs/chmod_windows.go`

### Why
CI was failing on PR #1160 with:
```
Boilerplate header is wrong for: pkg/nfs/chmod_unix.go
Boilerplate header is wrong for: pkg/nfs/chmod_unix_test.go
Boilerplate header is wrong for: pkg/nfs/chmod_windows.go
```

The build constraint was placed before the license header, but the boilerplate checker expects the license to come first.

/kind bug
