### PR TITLE
cleanup: add validation on volumeid

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -836,6 +836,9 @@ func getNfsVolFromID(id string) (*nfsVolume, error) {
 	if err := validatePath(baseDir); err != nil {
 		return nil, fmt.Errorf("invalid baseDir %q: %v", baseDir, err)
 	}
+	if err := validatePath(uuid); err != nil {
+		return nil, fmt.Errorf("invalid uuid %q: %v", uuid, err)
+	}
 
 	return &nfsVolume{
 		id:       id,

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1607,6 +1607,12 @@ func TestGetNfsVolFromID(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name:      "uuid with path traversal should be rejected",
+			volumeID:  "test-server#base#subdir#../../etc/shadow#delete",
+			expected:  nil,
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
Add `validatePath` check on the uuid field in `getNfsVolFromID()` to be consistent with the existing validation on `subDir` and `baseDir` fields.

```
if err := validatePath(uuid); err != nil {
    return nil, fmt.Errorf("invalid uuid %%q: %%v", uuid, err)
}
```