### PR TITLE
chore: publish helm chart to GitHub Pages via chart-releaser-action

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -12,7 +12,7 @@ name: Publish Helm Chart to GitHub Pages
 #   helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 #   helm repo update
 #   helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
-#     --namespace kube-system --version <x.y.z>
+#     --namespace kube-system --version 4.13.4
 
 on:
   push:
@@ -27,7 +27,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
 
 jobs:
   release:
@@ -55,6 +54,11 @@ jobs:
           if [ -n "${{ github.event.inputs.chart_version }}" ]; then
             version="${{ github.event.inputs.chart_version }}"
           else
+            # Require a tag ref when chart_version is not provided.
+            if [[ "$GITHUB_REF" != refs/tags/* ]]; then
+              echo "::error::chart_version input is empty and GITHUB_REF ($GITHUB_REF) is not a tag. Please provide a chart_version or run this workflow from a tag." >&2
+              exit 1
+            fi
             # Strip leading refs/tags/ and any leading 'v' (charts are semver, no v-prefix since 4.11.0).
             raw="${GITHUB_REF#refs/tags/}"
             version="${raw#v}"

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -12,7 +12,7 @@ name: Publish Helm Chart to GitHub Pages
 #   helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 #   helm repo update csi-driver-nfs
 #   helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
-#     --namespace kube-system --version 4.13.4
+#     --namespace kube-system --version <x.y.z>
 
 on:
   push:

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -97,8 +97,10 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: .cr-charts
-          # Skip creating a GitHub Release for this chart if one already
-          # exists at the same tag (the driver release itself owns the tag).
+          # Skip uploading if a chart release already exists for this version
+          # (e.g. on workflow re-runs). chart-releaser names releases as
+          # <chart-name>-<version> (e.g. csi-driver-nfs-4.13.4), so they do
+          # not collide with the driver's own v* tag releases.
           skip_existing: true
           # Publish index.yaml to the gh-pages branch (default).
           # Repo Settings -> Pages must be configured to serve from gh-pages.

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -10,7 +10,7 @@ name: Publish Helm Chart to GitHub Pages
 #
 # After the first successful run, users can install the chart with:
 #   helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
-#   helm repo update
+#   helm repo update csi-driver-nfs
 #   helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
 #     --namespace kube-system --version 4.13.4
 
@@ -59,7 +59,9 @@ jobs:
               echo "::error::chart_version input is empty and GITHUB_REF ($GITHUB_REF) is not a tag. Please provide a chart_version or run this workflow from a tag." >&2
               exit 1
             fi
-            # Strip leading refs/tags/ and any leading 'v' (charts are semver, no v-prefix since 4.11.0).
+            # Strip leading 'v' — charts are semver without v-prefix since 4.11.0.
+            # This workflow only triggers on new v* tags, so pre-4.11.0 tags
+            # (which used a v-prefixed chart version) are not affected.
             raw="${GITHUB_REF#refs/tags/}"
             version="${raw#v}"
           fi

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -74,6 +74,22 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Publishing chart version: $version"
 
+      - name: Checkout release tag
+        # When chart_version is provided via workflow_dispatch, ensure we
+        # package the chart source from the matching release tag, not the
+        # branch HEAD (which may contain unreleased changes).
+        if: github.event.inputs.chart_version != ''
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          tag="v${version}"
+          if ! git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::Tag ${tag} not found. Cannot package chart from an untagged version."
+            exit 1
+          fi
+          echo "Checking out tag ${tag}"
+          git checkout "refs/tags/${tag}"
+
       - name: Stage versioned chart for chart-releaser-action
         # chart-releaser-action expects each chart to live under a directory
         # whose Chart.yaml declares the release version. The in-tree source at

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: v3.14.0
 
@@ -52,7 +52,9 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "${{ github.event.inputs.chart_version }}" ]; then
-            version="${{ github.event.inputs.chart_version }}"
+            # Strip leading 'v' if provided (e.g. user enters v4.13.4 -> 4.13.4)
+            input="${{ github.event.inputs.chart_version }}"
+            version="${input#v}"
           else
             # Require a tag ref when chart_version is not provided.
             if [[ "$GITHUB_REF" != refs/tags/* ]]; then
@@ -92,7 +94,7 @@ jobs:
           cat .cr-charts/csi-driver-nfs/Chart.yaml
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: .cr-charts
           # Skip creating a GitHub Release for this chart if one already

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -1,0 +1,98 @@
+name: Publish Helm Chart to GitHub Pages
+
+# Publishes the chart source under charts/latest/csi-driver-nfs as an OCI-less
+# Helm repository hosted on GitHub Pages, using chart-releaser-action.
+#
+# This is additive: the existing raw.githubusercontent.com repository (backed
+# by charts/index.yaml and pre-packaged tgz files under charts/vX.Y.Z/) is
+# untouched. GitHub Pages is offered as an alternate installation source that
+# is not affected by rate limits on raw.githubusercontent.com (see #995).
+#
+# After the first successful run, users can install the chart with:
+#   helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
+#   helm repo update
+#   helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
+#     --namespace kube-system --version <x.y.z>
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      chart_version:
+        description: 'Chart version to publish (e.g. 4.13.5). Leave blank to reuse the git tag.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Determine chart version
+        id: version
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.chart_version }}" ]; then
+            version="${{ github.event.inputs.chart_version }}"
+          else
+            # Strip leading refs/tags/ and any leading 'v' (charts are semver, no v-prefix since 4.11.0).
+            raw="${GITHUB_REF#refs/tags/}"
+            version="${raw#v}"
+          fi
+          if [ -z "$version" ]; then
+            echo "Could not determine chart version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing chart version: $version"
+
+      - name: Stage versioned chart for chart-releaser-action
+        # chart-releaser-action expects each chart to live under a directory
+        # whose Chart.yaml declares the release version. The in-tree source at
+        # charts/latest/csi-driver-nfs uses the placeholder version v0.0.0, so
+        # copy it into a staging directory (.cr-charts/csi-driver-nfs) and
+        # rewrite version + appVersion to the release version.
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          rm -rf .cr-charts .cr-release-packages
+          mkdir -p .cr-charts
+          cp -r charts/latest/csi-driver-nfs .cr-charts/csi-driver-nfs
+          sed -i \
+            -e "s/^version: .*/version: ${version}/" \
+            -e "s/^appVersion: .*/appVersion: ${version}/" \
+            .cr-charts/csi-driver-nfs/Chart.yaml
+          echo "--- staged Chart.yaml ---"
+          cat .cr-charts/csi-driver-nfs/Chart.yaml
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: .cr-charts
+          # Skip creating a GitHub Release for this chart if one already
+          # exists at the same tag (the driver release itself owns the tag).
+          skip_existing: true
+          # Publish index.yaml to the gh-pages branch (default).
+          # Repo Settings -> Pages must be configured to serve from gh-pages.
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/README.md
+++ b/charts/README.md
@@ -19,6 +19,8 @@
 
 #### Option A: GitHub Pages (recommended)
 Hosted via GitHub Pages, not affected by rate limits on `raw.githubusercontent.com` (see [#995](https://github.com/kubernetes-csi/csi-driver-nfs/issues/995)).
+
+> **Note:** This option requires GitHub Pages to be enabled on the repo and at least one chart version to be published. If the URL does not resolve yet, use Option B below.
 ```console
 helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 helm repo update csi-driver-nfs

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,6 +17,15 @@
 > [!IMPORTANT]  
 > Starting from version `4.11.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `4.11.0` instead of `v4.11.0`.
 
+#### Option A: GitHub Pages (recommended)
+Hosted via GitHub Pages, not affected by rate limits on `raw.githubusercontent.com` (see [#995](https://github.com/kubernetes-csi/csi-driver-nfs/issues/995)).
+```console
+helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
+helm repo update csi-driver-nfs
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0
+```
+
+#### Option B: raw.githubusercontent.com (legacy)
 ```console
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
 helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0

--- a/charts/README.md
+++ b/charts/README.md
@@ -30,6 +30,7 @@ helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-syste
 #### Option B: raw.githubusercontent.com (legacy)
 ```console
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+helm repo update csi-driver-nfs
 helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,21 +17,9 @@
 > [!IMPORTANT]  
 > Starting from version `4.11.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `4.11.0` instead of `v4.11.0`.
 
-#### Option A: GitHub Pages (recommended)
-Hosted via GitHub Pages, not affected by rate limits on `raw.githubusercontent.com` (see [#995](https://github.com/kubernetes-csi/csi-driver-nfs/issues/995)).
-
-> **Note:** This option requires GitHub Pages to be enabled on the repo and at least one chart version to be published. If the URL does not resolve yet, use Option B below.
-```console
-helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
-helm repo update csi-driver-nfs
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
-```
-
-#### Option B: raw.githubusercontent.com (legacy)
 ```console
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
-helm repo update csi-driver-nfs
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0
 ```
 
 ### install driver with customized driver name, deployment name

--- a/charts/README.md
+++ b/charts/README.md
@@ -22,13 +22,13 @@ Hosted via GitHub Pages, not affected by rate limits on `raw.githubusercontent.c
 ```console
 helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 helm repo update csi-driver-nfs
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 
 #### Option B: raw.githubusercontent.com (legacy)
 ```console
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 
 ### install driver with customized driver name, deployment name


### PR DESCRIPTION
**Refs #995**

## Why

Since GitHub started aggressively rate-limiting `raw.githubusercontent.com`, users installing the chart via the documented URL keep hitting `Error: 429 Too Many Requests` (e.g. ArgoCD, CGNAT users). Migrating to ArtifactHub or GHCR runs into k8s-sigs org/permission constraints. GitHub Pages is the low-friction option — it only needs repo write + Settings → Pages toggle, no org owner or `packages:write` scope.

## What this PR does

Adds an **additive** GitHub Actions workflow `.github/workflows/publish-helm-chart.yaml` that on any `v*` tag push (or manual dispatch):

1. Copies `charts/latest/csi-driver-nfs` into a staging dir.
2. Substitutes the release version into `Chart.yaml` (`version` and `appVersion`), stripping the leading `v` (semver, per README note about 4.11.0+).
3. Runs [`helm/chart-releaser-action@v1.7.0`](https://github.com/helm/chart-releaser-action) which packages the chart, uploads the tgz as a GitHub Release asset (skipped if the release already exists — the driver tag owns it), and publishes `index.yaml` to the `gh-pages` branch.

## Backward compatibility

- **No existing files are removed or moved.** `charts/index.yaml`, `charts/vX.Y.Z/*.tgz`, and `charts/artifacthub-repo.yml` are all untouched.
- The current install URL keeps working:
  ```
  helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
  ```
- The new URL is offered as **Option A (recommended)** in `charts/README.md`, with the legacy URL kept as **Option B**:
  ```
  helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
  ```

## Follow-up actions needed after merge

Maintainers need to perform these **one-time** steps:

1. **Enable GitHub Pages on the repo:**
   Settings → Pages → Source: `Deploy from a branch` → Branch: `gh-pages` / `/ (root)`
   (The workflow creates the `gh-pages` branch automatically on first run.)

2. **Trigger the workflow manually to publish the current latest version (v4.13.4):**
   Actions → "Publish Helm Chart to GitHub Pages" → Run workflow → set `chart_version` to `4.13.4` → Run
   (This backfills the latest release into the GitHub Pages index. Future `v*` tag pushes will publish automatically.)

3. **Verify the new repo works:**
   ```
   helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
   helm repo update csi-driver-nfs
   helm search repo csi-driver-nfs
   ```

## Prior art

Same pattern used by [node-feature-discovery #2091 / #2297 / #2301](https://github.com/kubernetes-sigs/node-feature-discovery/issues/2091) (they went the OCI/`registry.k8s.io` route eventually, but chart-releaser + GH Pages is what most kubernetes-sigs charts still use and is a strict superset of the current raw-URL setup).