### PR TITLE
fix: work around chart-releaser skipping publish when charts_dir has no git diff

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -90,36 +90,40 @@ jobs:
           echo "Checking out tag ${tag}"
           git checkout "refs/tags/${tag}"
 
-      - name: Package chart
-        # chart-releaser-action's default "discover changed charts" step diffs
-        # charts_dir against the latest git tag; since we stage the chart
-        # into an untracked directory, it would always report "no changes"
-        # and skip publishing. Instead, package the chart ourselves and let
-        # chart-releaser only handle upload + index update via
-        # skip_packaging: true.
+      - name: Stage chart for chart-releaser
+        # chart-releaser-action's default flow uses `git diff <latest_tag>` to
+        # detect which charts changed. Two constraints steer this step:
+        #   1. `skip_packaging: true` is unusable in v1.7.0 because cr.sh
+        #      references `${latest_tag}` after skipping its assignment,
+        #      which trips `set -o nounset` and fails the run.
+        #   2. `charts/latest/csi-driver-nfs` may not have diffs vs the last
+        #      release tag (e.g. on manual dispatch of an existing version),
+        #      in which case chart-releaser would exit as a no-op with
+        #      "Nothing to do. No chart changes detected."
+        # Stage the chart into a fresh directory, rewrite Chart.yaml, then
+        # create a local-only temporary commit so `git diff` reports the
+        # staged chart as a change. The commit is never pushed; the runner
+        # checkout is discarded when the job ends.
         run: |
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
-          rm -rf .cr-staging .cr-release-packages
-          mkdir -p .cr-staging .cr-release-packages
-          cp -r charts/latest/csi-driver-nfs .cr-staging/csi-driver-nfs
+          rm -rf .cr-charts .cr-release-packages
+          mkdir -p .cr-charts
+          cp -r charts/latest/csi-driver-nfs .cr-charts/csi-driver-nfs
           sed -i \
             -e "s/^version: .*/version: ${version}/" \
             -e "s/^appVersion: .*/appVersion: ${version}/" \
-            .cr-staging/csi-driver-nfs/Chart.yaml
+            .cr-charts/csi-driver-nfs/Chart.yaml
           echo "--- staged Chart.yaml ---"
-          cat .cr-staging/csi-driver-nfs/Chart.yaml
-          helm package .cr-staging/csi-driver-nfs -d .cr-release-packages
-          ls -la .cr-release-packages
+          cat .cr-charts/csi-driver-nfs/Chart.yaml
+          # Local-only temp commit so chart-releaser's git diff sees the chart.
+          git add -f .cr-charts
+          git commit -m "ci: stage chart ${version} for chart-releaser" >/dev/null
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
-          # Skip packaging: we already produced the tgz under
-          # .cr-release-packages above. This also bypasses the built-in
-          # "discover changed charts" diff, which would otherwise report
-          # no changes because our staged chart lives outside the repo tree.
-          skip_packaging: true
+          charts_dir: .cr-charts
           # Skip uploading if a chart release already exists for this version
           # (e.g. on workflow re-runs). chart-releaser names releases as
           # <chart-name>-<version> (e.g. csi-driver-nfs-4.13.4), so they do

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -90,29 +90,36 @@ jobs:
           echo "Checking out tag ${tag}"
           git checkout "refs/tags/${tag}"
 
-      - name: Stage versioned chart for chart-releaser-action
-        # chart-releaser-action expects each chart to live under a directory
-        # whose Chart.yaml declares the release version. The in-tree source at
-        # charts/latest/csi-driver-nfs uses the placeholder version v0.0.0, so
-        # copy it into a staging directory (.cr-charts/csi-driver-nfs) and
-        # rewrite version + appVersion to the release version.
+      - name: Package chart
+        # chart-releaser-action's default "discover changed charts" step diffs
+        # charts_dir against the latest git tag; since we stage the chart
+        # into an untracked directory, it would always report "no changes"
+        # and skip publishing. Instead, package the chart ourselves and let
+        # chart-releaser only handle upload + index update via
+        # skip_packaging: true.
         run: |
           set -euo pipefail
           version="${{ steps.version.outputs.version }}"
-          rm -rf .cr-charts .cr-release-packages
-          mkdir -p .cr-charts
-          cp -r charts/latest/csi-driver-nfs .cr-charts/csi-driver-nfs
+          rm -rf .cr-staging .cr-release-packages
+          mkdir -p .cr-staging .cr-release-packages
+          cp -r charts/latest/csi-driver-nfs .cr-staging/csi-driver-nfs
           sed -i \
             -e "s/^version: .*/version: ${version}/" \
             -e "s/^appVersion: .*/appVersion: ${version}/" \
-            .cr-charts/csi-driver-nfs/Chart.yaml
+            .cr-staging/csi-driver-nfs/Chart.yaml
           echo "--- staged Chart.yaml ---"
-          cat .cr-charts/csi-driver-nfs/Chart.yaml
+          cat .cr-staging/csi-driver-nfs/Chart.yaml
+          helm package .cr-staging/csi-driver-nfs -d .cr-release-packages
+          ls -la .cr-release-packages
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
-          charts_dir: .cr-charts
+          # Skip packaging: we already produced the tgz under
+          # .cr-release-packages above. This also bypasses the built-in
+          # "discover changed charts" diff, which would otherwise report
+          # no changes because our staged chart lives outside the repo tree.
+          skip_packaging: true
           # Skip uploading if a chart release already exists for this version
           # (e.g. on workflow re-runs). chart-releaser names releases as
           # <chart-name>-<version> (e.g. csi-driver-nfs-4.13.4), so they do


### PR DESCRIPTION
## What this PR does

Fix follow-up to #1204. The GitHub Pages helm chart workflow was completing successfully but doing nothing:

```
Looking up latest tag...
Discovering changed charts since 'v4.13.3'...
Nothing to do. No chart changes detected.
```

## Root cause

`chart-releaser-action` uses `git diff <latest_tag>` on `charts_dir` to decide which charts changed. Our previous workflow staged the chart into an **untracked** `.cr-charts/` directory (created at runtime, never committed), so the diff always reported "no chart changes" and the run exited without creating the `gh-pages` branch, an `index.yaml`, or a GitHub Release.

## Why not `skip_packaging: true`

Initially considered, but chart-releaser-action v1.7.0's `cr.sh` has a bug: with `set -o nounset` enabled it unconditionally references `${latest_tag}` at the end of `main`, even though `latest_tag` is only assigned in the non-skip-packaging branch. Setting `skip_packaging: true` therefore fails the step before publishing.

## Fix

Keep chart-releaser doing the packaging + publish, but make its `git diff` see the staged chart:

- Copy `charts/latest/csi-driver-nfs` into `.cr-charts/csi-driver-nfs` and rewrite `Chart.yaml` `version` / `appVersion` to the release version
- Create a **local-only temporary commit** for `.cr-charts/` on the runner — never pushed; the checkout is discarded when the job ends
- Chart-releaser's `git diff <latest_tag>` now sees the staged chart as changed and packages/publishes it normally

## Testing

After merge, re-run the workflow via **Actions -> Publish Helm Chart to GitHub Pages -> Run workflow** with `chart_version: 4.13.4`. Expected result:
- `gh-pages` branch is created with `index.yaml`
- A GitHub Release named `csi-driver-nfs-4.13.4` is created with the chart tgz attached
- `Settings -> Pages` now has `gh-pages` selectable as source

/kind bug
/sig storage
/assign @andyzhangx