### PR TITLE
fix: bootstrap gh-pages branch before running chart-releaser

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -95,9 +95,8 @@ jobs:
         # already exist on the remote (it fails with "fatal: invalid
         # reference: origin/gh-pages" otherwise). Bootstrap an empty orphan
         # branch on the first run so subsequent chart-releaser steps can
-        # commit index.yaml into it.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # commit index.yaml into it. Git auth is handled by
+        # actions/checkout's persisted credentials above.
         run: |
           set -euo pipefail
           if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -90,6 +90,46 @@ jobs:
           echo "Checking out tag ${tag}"
           git checkout "refs/tags/${tag}"
 
+      - name: Ensure gh-pages branch exists
+        # chart-releaser's `cr upload` step requires the gh-pages branch to
+        # already exist on the remote (it fails with "fatal: invalid
+        # reference: origin/gh-pages" otherwise). Bootstrap an empty orphan
+        # branch on the first run so subsequent chart-releaser steps can
+        # commit index.yaml into it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "gh-pages branch already exists on origin."
+            exit 0
+          fi
+          echo "gh-pages branch not found on origin; bootstrapping empty orphan branch."
+          tmpdir="$(mktemp -d)"
+          git worktree add --detach "$tmpdir"
+          pushd "$tmpdir" >/dev/null
+          git checkout --orphan gh-pages
+          git rm -rf . >/dev/null 2>&1 || true
+          cat > README.md <<'EOF'
+          # csi-driver-nfs helm chart repository
+
+          This branch hosts the Helm chart repository for csi-driver-nfs via
+          GitHub Pages. Published automatically by the
+          `Publish Helm Chart to GitHub Pages` workflow.
+
+          To use:
+
+              helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
+              helm repo update csi-driver-nfs
+              helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs \
+                --namespace kube-system --version <x.y.z>
+          EOF
+          git add README.md
+          git commit -m "chore: bootstrap gh-pages branch for helm chart repository" >/dev/null
+          git push origin gh-pages
+          popd >/dev/null
+          git worktree remove --force "$tmpdir"
+
       - name: Stage chart for chart-releaser
         # chart-releaser-action's default flow uses `git diff <latest_tag>` to
         # detect which charts changed. Two constraints steer this step:


### PR DESCRIPTION
## What this PR does

Follow-up to #1206. The Publish Helm Chart to GitHub Pages workflow now packages the chart correctly, but `cr upload` still fails on the first run:

```
Successfully packaged chart in ... .cr-release-packages/csi-driver-nfs-4.13.4.tgz
Releasing charts...
fatal: invalid reference: origin/gh-pages
Error: exit status 128
```

## Root cause

`chart-releaser`'s `cr upload` step requires the `gh-pages` branch to already exist on the remote — it fetches `origin/gh-pages` as its base to commit `index.yaml` into. On a repo that has never published via GitHub Pages, that ref does not exist yet, so the step crashes before publishing anything.

## Fix

Add a pre-step that:
- Uses `git ls-remote --exit-code --heads origin gh-pages` to check whether the branch already exists
- If not, creates an empty orphan `gh-pages` branch in a temporary `git worktree` (so the release-tag checkout used by the packaging step is not disturbed), commits a README pointing at the helm repo, and pushes it
- On subsequent runs, the check is a no-op

## Testing

After merge, re-run **Actions -> Publish Helm Chart to GitHub Pages -> Run workflow** with `chart_version: 4.13.4`. Expected result:
- First run bootstraps `gh-pages` with README.md
- Same run then publishes `csi-driver-nfs-4.13.4` GitHub Release + updates `index.yaml` on `gh-pages`
- Follow-up: enable `Settings -> Pages` sourced from `gh-pages`

/kind bug
/sig storage
/assign @andyzhangx