### PR TITLE
fix: rename --repo to --git-repo for cr upload/index

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -169,13 +169,13 @@ jobs:
           # attach the packaged tgz. --skip-existing makes re-runs idempotent.
           cr upload \
             --owner "$owner" \
-            --repo "$repo" \
+            --git-repo "$repo" \
             --commit "$commit" \
             --token "$CR_TOKEN" \
             --skip-existing
           # Update index.yaml on the gh-pages branch and push it.
           cr index \
             --owner "$owner" \
-            --repo "$repo" \
+            --git-repo "$repo" \
             --token "$CR_TOKEN" \
             --push


### PR DESCRIPTION
## What this PR does

Follow-up to #1208. The Publish Helm Chart to GitHub Pages workflow now runs `cr` directly, but hits an unknown-flag error:

```
Error: unknown flag: --repo
```

`cr` (chart-releaser) exposes the repo flag as `--git-repo` (short `-r`), not `--repo`. Rename both call sites (`cr upload` and `cr index`).

## Testing

Re-run **Actions -> Publish Helm Chart to GitHub Pages -> Run workflow** with `chart_version: 4.13.4`. Expected result:
- `csi-driver-nfs-4.13.4` GitHub Release is created at the v4.13.4 tag commit with the chart tgz attached
- `gh-pages` gets an updated `index.yaml`

/kind bug
/sig storage
/assign @andyzhangx