### PR TITLE
fix: publish chart tgz on gh-pages instead of GitHub Releases

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -171,6 +171,5 @@ jobs:
             --owner "$owner" \
             --git-repo "$repo" \
             --token "$CR_TOKEN" \
-            --index-path . \
             --packages-with-index \
             --push

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -157,25 +157,26 @@ jobs:
           helm package .cr-staging/csi-driver-nfs -d .cr-release-packages
           ls -la .cr-release-packages
 
-      - name: Release chart and update index
+      - name: Publish chart on gh-pages
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
-          commit="${{ steps.package.outputs.tag_sha }}"
-          # Create GitHub Release csi-driver-nfs-<version> at the tag SHA and
-          # attach the packaged tgz. --skip-existing makes re-runs idempotent.
-          cr upload \
-            --owner "$owner" \
-            --git-repo "$repo" \
-            --commit "$commit" \
-            --token "$CR_TOKEN" \
-            --skip-existing
-          # Update index.yaml on the gh-pages branch and push it.
+          # Publish the chart directly on the gh-pages branch (both the tgz
+          # package and index.yaml). We deliberately do NOT call `cr upload`
+          # to create a GitHub Release: the org-scoped GITHUB_TOKEN in
+          # kubernetes-csi cannot create Releases (Releases API returns 403
+          # "Resource not accessible by integration" even with
+          # `permissions: contents: write`). Hosting the tgz on gh-pages
+          # side-steps that restriction, and the resulting helm repo
+          # (https://kubernetes-csi.github.io/csi-driver-nfs) still works
+          # the same way for users.
           cr index \
             --owner "$owner" \
             --git-repo "$repo" \
             --token "$CR_TOKEN" \
+            --index-path . \
+            --packages-with-index \
             --push

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -136,12 +136,6 @@ jobs:
             echo "::error::Tag ${tag} not found. Cannot package chart from an untagged version."
             exit 1
           fi
-          # Dereference to the commit SHA. csi-driver-nfs uses annotated,
-          # signed tags (see RELEASE.md); rev-parsing the tag ref directly
-          # would return the tag object SHA, which GitHub rejects as an
-          # invalid target_commitish for release creation.
-          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
-          echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
           rm -rf .cr-staging .cr-release-packages
           mkdir -p .cr-staging .cr-release-packages
           # Extract the chart source from the release tag without changing HEAD.


### PR DESCRIPTION
## What this PR does

Follow-up to #1209. The last Publish Helm Chart to GitHub Pages run failed at `cr upload`:

```
Successfully packaged chart and saved it to: .cr-release-packages/csi-driver-nfs-4.13.4.tgz
...
Error: error creating GitHub release csi-driver-nfs-4.13.4:
  POST https://api.github.com/repos/kubernetes-csi/csi-driver-nfs/releases:
  403 Resource not accessible by integration
```

## Root cause

The `kubernetes-csi` org policy blocks the default `GITHUB_TOKEN` from creating GitHub Releases even when the workflow explicitly requests `permissions: contents: write`. In the same run the workflow pushed to `gh-pages` successfully, so git write access is fine — only the Releases API is restricted.

## Fix

Drop the GitHub Release step entirely. Publish the chart tgz on the `gh-pages` branch alongside `index.yaml` using `cr index --packages-with-index --push`:

- Users still get the same helm repo URL: `https://kubernetes-csi.github.io/csi-driver-nfs`
- `.tgz` assets are served directly by GitHub Pages instead of via Releases
- No dependency on the Releases API → org policy no longer blocks us

## Testing

Re-run **Actions -> Publish Helm Chart to GitHub Pages -> Run workflow** with `chart_version: 4.13.4`. Expected result:
- `gh-pages` contains `index.yaml` + `csi-driver-nfs-4.13.4.tgz`
- `helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs && helm search repo csi-driver-nfs` shows `4.13.4`

/kind bug
/sig storage
/assign @andyzhangx