### PR TITLE
docs(charts): document GitHub Pages helm repo as an additional install option

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -27,9 +27,11 @@ helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/cs
 helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 ```
 
-Then install:
+Then update the repo cache, search for available versions, and install:
 
 ```console
+helm repo update csi-driver-nfs
+helm search repo csi-driver-nfs
 helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,9 +17,24 @@
 > [!IMPORTANT]  
 > Starting from version `4.11.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `4.11.0` instead of `v4.11.0`.
 
+The chart is published to two Helm repositories. Either one works — pick whichever is more reliable from your network.
+
+#### Option 1: raw.githubusercontent.com (default)
+
 ```console
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.12.0
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
+```
+
+#### Option 2: GitHub Pages (mirror)
+
+Available starting from version `4.13.4`. Not affected by `raw.githubusercontent.com` rate limits (see [#995](https://github.com/kubernetes-csi/csi-driver-nfs/issues/995)).
+
+```console
+helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
+helm repo update csi-driver-nfs
+helm search repo csi-driver-nfs
+helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 
 ### install driver with customized driver name, deployment name

--- a/charts/README.md
+++ b/charts/README.md
@@ -17,23 +17,19 @@
 > [!IMPORTANT]  
 > Starting from version `4.11.0`, the prefix `v` is removed from helm chart release so they are in line with [semver](https://semver.org). Therefore, when upgrading, refer to version `4.11.0` instead of `v4.11.0`.
 
-The chart is published to two Helm repositories. Either one works — pick whichever is more reliable from your network.
-
-#### Option 1: raw.githubusercontent.com (default)
+Add the helm repo (pick either source — both host the same charts):
 
 ```console
+# Option 1: raw.githubusercontent.com (default)
 helm repo add csi-driver-nfs https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
-helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
+
+# Option 2: GitHub Pages mirror (available since 4.13.4, not affected by raw.githubusercontent.com rate limits, see #995)
+helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
 ```
 
-#### Option 2: GitHub Pages (mirror)
-
-Available starting from version `4.13.4`. Not affected by `raw.githubusercontent.com` rate limits (see [#995](https://github.com/kubernetes-csi/csi-driver-nfs/issues/995)).
+Then install:
 
 ```console
-helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
-helm repo update csi-driver-nfs
-helm search repo csi-driver-nfs
 helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
 


### PR DESCRIPTION
## What this PR does

Follow-up to #1204. Now that the chart is also published to `https://kubernetes-csi.github.io/csi-driver-nfs` via GitHub Pages, document both install options in `charts/README.md`.

- **Option 1 (default, unchanged):** `https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts`
- **Option 2 (new, additive):** `https://kubernetes-csi.github.io/csi-driver-nfs` — not subject to raw.githubusercontent.com rate limits (#995)

The raw.githubusercontent.com repository is **NOT deprecated**. Users can pick whichever is more reliable from their network.

Also bumps the example version from `4.12.0` -> `4.13.4` (latest chart).

## Testing

```console
helm repo add csi-driver-nfs https://kubernetes-csi.github.io/csi-driver-nfs
helm repo update csi-driver-nfs
helm search repo csi-driver-nfs
NAME                            CHART VERSION   APP VERSION     DESCRIPTION
csi-driver-nfs/csi-driver-nfs   4.13.4          4.13.4          CSI NFS Driver for Kubernetes
```

/kind documentation
/sig storage
/assign @andyzhangx

Fixes #995