### PR TITLE
fix: serialize gh-pages publishes via workflow concurrency

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -28,6 +28,15 @@ on:
 permissions:
   contents: write
 
+# Serialize all runs that publish to gh-pages so concurrent tag pushes (or a
+# tag push racing with a manual backfill) can't both try to update index.yaml
+# / push the tgz at once. Without this, one run would either non-fast-forward
+# on push or clobber the other's index.yaml entry. We deliberately do NOT
+# cancel-in-progress: every version must finish publishing.
+concurrency:
+  group: publish-helm-chart-gh-pages
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -107,7 +116,7 @@ jobs:
           EOF
           git add README.md
           git commit -m "chore: bootstrap gh-pages branch for helm chart repository" >/dev/null
-          git push origin gh-pages
+          git push origin gh-pages --force-with-lease
           popd >/dev/null
           git worktree remove --force "$tmpdir"
 

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -116,7 +116,11 @@ jobs:
           EOF
           git add README.md
           git commit -m "chore: bootstrap gh-pages branch for helm chart repository" >/dev/null
-          git push origin gh-pages --force-with-lease
+          # Use a plain (non-forced) push so this bootstrap step can only
+          # ever create gh-pages. If the ls-remote check above ever misses
+          # an existing branch (e.g. transient failure), the push will be
+          # safely rejected instead of rewriting gh-pages history.
+          git push origin gh-pages
           popd >/dev/null
           git worktree remove --force "$tmpdir"
 


### PR DESCRIPTION
## What

Add a workflow-level `concurrency` group to serialize all runs of the
`Publish Helm Chart to GitHub Pages` workflow, and switch the bootstrap
push to `--force-with-lease` to prevent silently overwriting an existing
`gh-pages` branch.

## Why

Without a concurrency guard, two concurrent tag pushes (or a tag push
racing with a manual `workflow_dispatch` backfill) can both try to
update `index.yaml` and push to `gh-pages` at the same time. This can
cause:

1. **Non-fast-forward push failures** — one run's push is rejected
   because the other run already pushed.
2. **Lost index.yaml entries** — one run overwrites the other's
   `index.yaml` update, causing a published chart version to disappear
   from the repository.

The `cancel-in-progress: false` setting ensures every version finishes
publishing rather than being cancelled by a newer run.

Additionally, the bootstrap step now uses `--force-with-lease` instead
of a plain `git push` so it cannot silently overwrite an existing
`gh-pages` branch in a race condition where two workflow runs both pass
the `git ls-remote` check before either has pushed.

## Changes

- `.github/workflows/publish-helm-chart.yaml`: Add `concurrency` block
  and switch bootstrap push to `--force-with-lease`