### PR TITLE
docs(charts): document HA controller requirements and hostNetwork port conflict

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -37,9 +37,9 @@ helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-syste
 
 ### High-availability controller
 
-`controller.replicas > 1` requires the same number of schedulable nodes as replicas. The controller Deployment uses `hostNetwork: true` (needed to mount NFS shares for CreateVolume), and its `liveness-probe` sidecar plus the `nfs` container's livenessProbe both bind a **fixed host port** (`controller.livenessProbe.healthPort`, default `29652`).
+`controller.replicas > 1` requires the same number of schedulable nodes as replicas. The controller Deployment uses `hostNetwork: true` (needed to mount NFS shares for CreateVolume), so all containers in the pod share the node's network namespace. Its `liveness-probe` sidecar listens on a **fixed host port** (`controller.livenessProbe.healthPort`, default `29652`), which the `nfs` container's livenessProbe HTTP-GETs.
 
-Scheduling two controller replicas onto the same node causes the second pod's `liveness-probe` container to fail binding the port, which trips the livenessProbe and puts the pod into `CrashLoopBackOff`.
+Scheduling two controller replicas onto the same node causes the second pod's `liveness-probe` sidecar to fail binding the port (already taken by the first pod), which trips the `nfs` container's livenessProbe and puts the pod into `CrashLoopBackOff`.
 
 To run controller replicas > 1:
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -6,7 +6,7 @@
 ### Tips
  - install csi snapshot controller: `--set externalSnapshotter.enabled=true`
  - run controller on control plane node: `--set controller.runOnControlPlane=true`
- - set replica of controller as `2`: `--set controller.replicas=2`
+ - set replica of controller as `2`: `--set controller.replicas=2` (requires ≥ 2 schedulable nodes — see [High-availability controller](#high-availability-controller) below)
  - Microk8s based kubernetes recommended settings(refer to https://microk8s.io/docs/nfs):
     - `--set controller.dnsPolicy=ClusterFirstWithHostNet` with `--set node.dnsPolicy=ClusterFirstWithHostNet` -
       external smb server cannot be found based on Default dns.
@@ -34,6 +34,32 @@ helm repo update csi-driver-nfs
 helm search repo csi-driver-nfs --versions
 helm install csi-driver-nfs csi-driver-nfs/csi-driver-nfs --namespace kube-system --version 4.13.4
 ```
+
+### High-availability controller
+
+`controller.replicas > 1` requires the same number of schedulable nodes as replicas. The controller Deployment uses `hostNetwork: true` (needed to mount NFS shares for CreateVolume), and its `liveness-probe` sidecar plus the `nfs` container's livenessProbe both bind a **fixed host port** (`controller.livenessProbe.healthPort`, default `29652`).
+
+Scheduling two controller replicas onto the same node causes the second pod's `liveness-probe` container to fail binding the port, which trips the livenessProbe and puts the pod into `CrashLoopBackOff`.
+
+To run controller replicas > 1:
+
+1. Ensure your cluster has at least `controller.replicas` schedulable nodes (single-node dev clusters like `k3d` / `kind` must keep `controller.replicas=1`).
+2. Add `podAntiAffinity` on `kubernetes.io/hostname` so replicas cannot co-locate:
+
+```yaml
+controller:
+  replicas: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app: csi-nfs-controller
+```
+
+> [!NOTE]
+> Leader-election log lines like `"Failed to update lease optimistically, falling back to slow path"` in the active controller are **normal noise** when there are 2+ candidates racing for the same lease. They do not indicate a bug.
 
 ### install driver with customized driver name, deployment name
 > only supported from `v3.1.0`+


### PR DESCRIPTION
## What this PR does

Documents in `charts/README.md` that `controller.replicas > 1` requires the same number of schedulable nodes as replicas, and explains why.

## Why

The controller Deployment uses `hostNetwork: true` (needed so CreateVolume can mount the NFS share to create sub-dirs), and the `liveness-probe` sidecar plus the `nfs` container's livenessProbe both bind a **fixed host port** (`controller.livenessProbe.healthPort`, default `29652`).

Scheduling two controller replicas onto the same node causes the second pod's `liveness-probe` container to fail binding the port, which trips the livenessProbe and puts the pod into `CrashLoopBackOff`. Users on single-node dev clusters (`k3d`, `kind`) who follow the current `--set controller.replicas=2` tip hit this immediately (see #1215).

## Changes

- `charts/README.md`:
  - Update the Tips section to link to the new HA section
  - Add a **High-availability controller** section explaining the constraint, offering a `podAntiAffinity` example, and clarifying that the `\"Failed to update lease optimistically\"` leader-election log lines are normal noise rather than a bug

No code / chart template changes in this PR. A separate follow-up can consider whether to make `podAntiAffinity` a chart default.

Fixes: #1215

/kind documentation
/sig storage
/assign @andyzhangx