### PR TITLE
fix: make Publish Helm Chart workflow idempotent for already-published versions

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -176,6 +176,18 @@ jobs:
           # even if a stale local ref exists, making the subsequent push a
           # fast-forward.
           git worktree add -B gh-pages "$workdir" origin/gh-pages
+          # Skip republishing if this exact version's tgz is already on
+          # gh-pages. `helm repo index` unconditionally rewrites the
+          # top-level `generated:` timestamp (and per-entry `created:`
+          # timestamps when re-packaging), so without this guard a rerun
+          # for an already-published version would produce a commit with
+          # only timestamp churn, spamming gh-pages history and making
+          # reruns non-idempotent.
+          if [ -f "$workdir/csi-driver-nfs-${version}.tgz" ]; then
+            echo "csi-driver-nfs-${version}.tgz already published on gh-pages; skipping republish."
+            git worktree remove --force "$workdir"
+            exit 0
+          fi
           cp "$pkg" "$workdir/"
           pushd "$workdir" >/dev/null
           # Merge the new tgz into the existing index.yaml (create one on


### PR DESCRIPTION
## What this PR does

Follow-up to make the `Publish Helm Chart to GitHub Pages` workflow idempotent when rerun for a version that has already been published to `gh-pages`.

## Problem

`helm repo index` unconditionally rewrites the top-level `generated:` timestamp (and per-entry `created:` timestamps when re-packaging), even when no new chart is added. Any rerun of this workflow for an already-published version — e.g. a `workflow_dispatch` backfill for a version already on `gh-pages`, or a re-pushed tag — would:

1. Re-run `helm repo index --merge`, rewriting `generated:`
2. Fail the `git diff --cached --quiet` check (new tgz mtime + rewritten `index.yaml` timestamps)
3. Commit + push a timestamp-only change to `gh-pages`

That spams `gh-pages` history and breaks the "reruns are safe" property the workflow implies.

## Fix

After `git worktree add -B gh-pages`, check whether `<driver>-${version}.tgz` already exists in the gh-pages worktree. If it does, clean up the worktree and `exit 0` before touching `helm repo index` or committing.

## Testing

- Fresh version (tgz absent): still packages, indexes, commits, pushes as before.
- Rerun for already-published version: prints skip message, removes worktree, exits — no `helm repo index` invocation, no commit, no push.

Mirrors the same fix landed on kubernetes-sigs/azurefile-csi-driver#3294 and kubernetes-sigs/azuredisk-csi-driver#3735.

/kind bug
/sig storage
/assign @andyzhangx
