### PR TITLE
fix: validate paths during snapshot creation

### DIFF
--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -180,7 +180,10 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}()
 
 	// Create subdirectory under base-dir
-	internalVolumePath := getInternalVolumePath(cs.Driver.workingMountDir, nfsVol)
+	internalVolumePath, err := getInternalVolumePath(cs.Driver.workingMountDir, nfsVol)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
 	if err = os.MkdirAll(internalVolumePath, 0777); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to make subdirectory: %v", err)
 	}
@@ -252,10 +255,17 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			}
 		}()
 
-		internalVolumePath := getInternalVolumePath(cs.Driver.workingMountDir, nfsVol)
+		internalVolumePath, err := getInternalVolumePath(cs.Driver.workingMountDir, nfsVol)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "%v", err)
+		}
+		internalMountPath, err := getInternalMountPath(cs.Driver.workingMountDir, nfsVol)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "%v", err)
+		}
 
 		if strings.EqualFold(nfsVol.onDelete, archive) {
-			archivedInternalVolumePath := filepath.Join(getInternalMountPath(cs.Driver.workingMountDir, nfsVol), "archived-"+nfsVol.subDir)
+			archivedInternalVolumePath := filepath.Join(internalMountPath, "archived-"+nfsVol.subDir)
 			if strings.Contains(nfsVol.subDir, "/") {
 				parentDir := filepath.Dir(archivedInternalVolumePath)
 				klog.V(2).Infof("DeleteVolume: subdirectory(%s) contains '/', make sure the parent directory(%s) exists", nfsVol.subDir, parentDir)
@@ -289,7 +299,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 			parentDir := filepath.Dir(internalVolumePath)
 			klog.V(2).Infof("DeleteVolume: removing empty directories in %s", parentDir)
-			if err = removeEmptyDirs(getInternalMountPath(cs.Driver.workingMountDir, nfsVol), parentDir); err != nil {
+			if err = removeEmptyDirs(internalMountPath, parentDir); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to remove empty directories: %v", err)
 			}
 		}
@@ -375,7 +385,10 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 			klog.Warningf("failed to unmount snapshot nfs server: %v", err)
 		}
 	}()
-	snapInternalVolPath := getInternalVolumePath(cs.Driver.workingMountDir, snapVol)
+	snapInternalVolPath, err := getInternalVolumePath(cs.Driver.workingMountDir, snapVol)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
 	if err = os.MkdirAll(snapInternalVolPath, 0777); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to make subdirectory: %v", err)
 	}
@@ -392,7 +405,10 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		}
 	}()
 
-	srcPath := getInternalVolumePath(cs.Driver.workingMountDir, srcVol)
+	srcPath, err := getInternalVolumePath(cs.Driver.workingMountDir, srcVol)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
 	dstPath := filepath.Join(snapInternalVolPath, snapshot.archiveName(cs.Driver.enableSnapshotCompression))
 
 	klog.V(2).Infof("tar %v -> %v", srcPath, dstPath)
@@ -454,7 +470,10 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 	}()
 
 	// delete snapshot archive
-	internalVolumePath := getInternalVolumePath(cs.Driver.workingMountDir, vol)
+	internalVolumePath, err := getInternalVolumePath(cs.Driver.workingMountDir, vol)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%v", err)
+	}
 	klog.V(2).Infof("Removing snapshot archive at %v", internalVolumePath)
 	if err = os.RemoveAll(internalVolumePath); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete subdirectory: %v", err)
@@ -493,7 +512,10 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 	}
 
 	sharePath := filepath.Join(string(filepath.Separator) + vol.baseDir)
-	targetPath := getInternalMountPath(cs.Driver.workingMountDir, vol)
+	targetPath, err := getInternalMountPath(cs.Driver.workingMountDir, vol)
+	if err != nil {
+		return err
+	}
 
 	volContext := map[string]string{
 		paramServer: vol.server,
@@ -512,7 +534,7 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 	}
 
 	klog.V(2).Infof("internally mounting %s:%s at %s", vol.server, sharePath, targetPath)
-	_, err := cs.Driver.ns.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
+	_, err = cs.Driver.ns.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
 		TargetPath:       targetPath,
 		VolumeContext:    volContext,
 		VolumeCapability: volCap,
@@ -523,11 +545,14 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 
 // Unmount nfs server at base-dir
 func (cs *ControllerServer) internalUnmount(ctx context.Context, vol *nfsVolume) error {
-	targetPath := getInternalMountPath(cs.Driver.workingMountDir, vol)
+	targetPath, err := getInternalMountPath(cs.Driver.workingMountDir, vol)
+	if err != nil {
+		return err
+	}
 
 	// Unmount nfs server at base-dir
 	klog.V(4).Infof("internally unmounting %v", targetPath)
-	_, err := cs.Driver.ns.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
+	_, err = cs.Driver.ns.NodeUnpublishVolume(ctx, &csi.NodeUnpublishVolumeRequest{
 		VolumeId:   vol.id,
 		TargetPath: targetPath,
 	})
@@ -564,7 +589,10 @@ func (cs *ControllerServer) copyFromSnapshot(ctx context.Context, req *csi.Creat
 	}()
 
 	// untar snapshot archive to dst path
-	snapInternalVolPath := getInternalVolumePath(cs.Driver.workingMountDir, snapVol)
+	snapInternalVolPath, err := getInternalVolumePath(cs.Driver.workingMountDir, snapVol)
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
 	// Try compressed archive first for backward compatibility, then uncompressed
 	enableCompression := true
 	snapPath := filepath.Join(snapInternalVolPath, snap.archiveName(true))
@@ -573,7 +601,10 @@ func (cs *ControllerServer) copyFromSnapshot(ctx context.Context, req *csi.Creat
 		snapPath = filepath.Join(snapInternalVolPath, snap.archiveName(false))
 		enableCompression = false
 	}
-	dstPath := getInternalVolumePath(cs.Driver.workingMountDir, dstVol)
+	dstPath, err := getInternalVolumePath(cs.Driver.workingMountDir, dstVol)
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
 	klog.V(2).Infof("copy volume from snapshot %v -> %v", snapPath, dstPath)
 
 	if cs.Driver.useTarCommandInSnapshot {
@@ -600,9 +631,16 @@ func (cs *ControllerServer) copyFromVolume(ctx context.Context, req *csi.CreateV
 	if err != nil {
 		return status.Error(codes.NotFound, err.Error())
 	}
+	srcVolPath, err := getInternalVolumePath(cs.Driver.workingMountDir, srcVol)
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
 	// Note that the source path must include trailing '/.', can't use 'filepath.Join()' as it performs path cleaning
-	srcPath := fmt.Sprintf("%v/.", getInternalVolumePath(cs.Driver.workingMountDir, srcVol))
-	dstPath := getInternalVolumePath(cs.Driver.workingMountDir, dstVol)
+	srcPath := fmt.Sprintf("%v/.", srcVolPath)
+	dstPath, err := getInternalVolumePath(cs.Driver.workingMountDir, dstVol)
+	if err != nil {
+		return status.Errorf(codes.Internal, "%v", err)
+	}
 	klog.V(2).Infof("copy volume from volume %v -> %v", srcPath, dstPath)
 
 	var volCap *csi.VolumeCapability
@@ -667,6 +705,11 @@ func newNFSSnapshot(name string, params map[string]string, vol *nfsVolume) (*nfs
 	if server == "" {
 		return nil, fmt.Errorf("%v is a required parameter", paramServer)
 	}
+	// baseDir comes from the snapshot class "share" parameter and flows into the
+	// internal mount path; validate it for parity with newNFSVolume.
+	if err := validatePath(baseDir); err != nil {
+		return nil, fmt.Errorf("invalid share %q: %v", baseDir, err)
+	}
 	snapshot := &nfsSnapshot{
 		server:  server,
 		baseDir: baseDir,
@@ -713,12 +756,13 @@ func newNFSVolume(name string, size int64, params map[string]string, defaultOnDe
 	if server == "" {
 		return nil, fmt.Errorf("%v is a required parameter", paramServer)
 	}
+	// Note: server is not run through validatePath; it is an NFS host, not a
+	// path component. A caller who controls the server value can only redirect
+	// the internal mount to an NFS server they already control, which is
+	// inherent to how the server is encoded in the volume ID.
 
 	if err := validatePath(baseDir); err != nil {
 		return nil, fmt.Errorf("invalid share %q: %v", baseDir, err)
-	}
-	if err := validatePath(subDir); err != nil {
-		return nil, fmt.Errorf("invalid subDir %q: %v", subDir, err)
 	}
 
 	vol := &nfsVolume{
@@ -736,6 +780,10 @@ func newNFSVolume(name string, size int64, params map[string]string, defaultOnDe
 		vol.uuid = name
 	}
 
+	if err := validatePath(vol.subDir); err != nil {
+		return nil, fmt.Errorf("invalid subDir %q: %v", vol.subDir, err)
+	}
+
 	if err := validateOnDeleteValue(onDelete); err != nil {
 		return nil, err
 	}
@@ -749,16 +797,34 @@ func newNFSVolume(name string, size int64, params map[string]string, defaultOnDe
 	return vol, nil
 }
 
+// validatePathWithinBase reports an error if path does not resolve to a
+// location within base. It is a defense-in-depth backstop for the internal
+// mount/volume paths: even if a caller-supplied component slips past the
+// validatePath checks performed when parsing volume/snapshot IDs, the
+// destructive filesystem operations keyed off these paths (os.MkdirAll,
+// os.RemoveAll, os.Rename) must never touch anything outside workingMountDir.
+// It shares the lexical containment check (isPathWithinBase) used by TarUnpack.
+func validatePathWithinBase(base, path string) error {
+	if !isPathWithinBase(base, path) {
+		return fmt.Errorf("resolved path %q escapes base directory %q", path, base)
+	}
+	return nil
+}
+
 // getInternalMountPath: get working directory for CreateVolume and DeleteVolume
-func getInternalMountPath(workingMountDir string, vol *nfsVolume) string {
+func getInternalMountPath(workingMountDir string, vol *nfsVolume) (string, error) {
 	if vol == nil {
-		return ""
+		return "", nil
 	}
 	mountDir := vol.uuid
 	if vol.uuid == "" {
 		mountDir = vol.subDir
 	}
-	return filepath.Join(workingMountDir, mountDir)
+	path := filepath.Join(workingMountDir, mountDir)
+	if err := validatePathWithinBase(workingMountDir, path); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // Get internal path where the volume is created
@@ -768,8 +834,16 @@ func getInternalMountPath(workingMountDir string, vol *nfsVolume) string {
 //     CreateVolume calls in parallel and they may use the same underlying share.
 //     Instead of refcounting how many CreateVolume calls are using the same
 //     share, it's simpler to just do a mount per request.
-func getInternalVolumePath(workingMountDir string, vol *nfsVolume) string {
-	return filepath.Join(getInternalMountPath(workingMountDir, vol), vol.subDir)
+func getInternalVolumePath(workingMountDir string, vol *nfsVolume) (string, error) {
+	mountPath, err := getInternalMountPath(workingMountDir, vol)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(mountPath, vol.subDir)
+	if err := validatePathWithinBase(workingMountDir, path); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // Given a nfsVolume, return a CSI volume id

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -797,16 +797,24 @@ func newNFSVolume(name string, size int64, params map[string]string, defaultOnDe
 	return vol, nil
 }
 
-// validatePathWithinBase reports an error if path does not resolve to a
-// location within base. It is a defense-in-depth backstop for the internal
+// validatePathWithinBase reports an error if path does not resolve to a strict
+// descendant of base. It is a defense-in-depth backstop for the internal
 // mount/volume paths: even if a caller-supplied component slips past the
 // validatePath checks performed when parsing volume/snapshot IDs, the
 // destructive filesystem operations keyed off these paths (os.MkdirAll,
 // os.RemoveAll, os.Rename) must never touch anything outside workingMountDir.
-// It shares the lexical containment check (isPathWithinBase) used by TarUnpack.
+// It shares the lexical containment check (isPathWithinBase) used by TarUnpack,
+// and additionally rejects path == base: an empty subDir/uuid component would
+// otherwise collapse the internal path to workingMountDir itself, letting
+// deletion run os.RemoveAll on the mounted share root. The equality check is
+// kept here rather than in isPathWithinBase because TarUnpack legitimately
+// resolves a "." archive entry to its destination root.
 func validatePathWithinBase(base, path string) error {
 	if !isPathWithinBase(base, path) {
 		return fmt.Errorf("resolved path %q escapes base directory %q", path, base)
+	}
+	if filepath.Clean(path) == filepath.Clean(base) {
+		return fmt.Errorf("resolved path %q must be a subdirectory of base directory %q", path, base)
 	}
 	return nil
 }

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -856,17 +856,33 @@ func getNfsVolFromID(id string) (*nfsVolume, error) {
 //	nfs-server.default.svc.cluster.local#share#snapshot-016f784f-56f4-44d1-9041-5f59e82dbce1#snapshot-016f784f-56f4-44d1-9041-5f59e82dbce1#pvc-4bcbf944-b6f7-4bd0-b50f-3c3dd00efc64
 func getNfsSnapFromID(id string) (*nfsSnapshot, error) {
 	segments := strings.Split(id, separator)
-	if len(segments) == totalIDSnapElements {
-		return &nfsSnapshot{
-			id:      id,
-			server:  segments[idSnapServer],
-			baseDir: segments[idSnapBaseDir],
-			src:     segments[idSnapArchiveName],
-			uuid:    segments[idSnapUUID],
-		}, nil
+	if len(segments) != totalIDSnapElements {
+		return &nfsSnapshot{}, fmt.Errorf("failed to create nfsSnapshot from snapshot ID")
 	}
 
-	return &nfsSnapshot{}, fmt.Errorf("failed to create nfsSnapshot from snapshot ID")
+	baseDir := segments[idSnapBaseDir]
+	uuid := segments[idSnapUUID]
+	src := segments[idSnapArchiveName]
+
+	// These fields flow into filesystem paths (mount targets, os.RemoveAll,
+	// tar archive paths); reject directory traversal sequences.
+	if err := validatePath(baseDir); err != nil {
+		return nil, fmt.Errorf("invalid baseDir %q: %v", baseDir, err)
+	}
+	if err := validatePath(uuid); err != nil {
+		return nil, fmt.Errorf("invalid uuid %q: %v", uuid, err)
+	}
+	if err := validatePath(src); err != nil {
+		return nil, fmt.Errorf("invalid src %q: %v", src, err)
+	}
+
+	return &nfsSnapshot{
+		id:      id,
+		server:  segments[idSnapServer],
+		baseDir: baseDir,
+		src:     src,
+		uuid:    uuid,
+	}, nil
 }
 
 // isValidVolumeCapabilities validates the given VolumeCapability array is valid

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -650,6 +650,14 @@ func TestInternalPathContainment(t *testing.T) {
 			vol:       &nfsVolume{subDir: "a/../../../etc", uuid: "uuid"},
 			expectErr: true,
 		},
+		{
+			// A malformed ID with empty subDir and uuid would collapse the
+			// internal path to workingMountDir itself; deletion must not run
+			// os.RemoveAll on the mounted share root.
+			desc:      "empty subDir and uuid must not resolve to base",
+			vol:       &nfsVolume{},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -1631,3 +1631,89 @@ func TestGetNfsVolFromID(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNfsSnapFromID(t *testing.T) {
+	cases := []struct {
+		name       string
+		snapshotID string
+		expected   *nfsSnapshot
+		expectErr  bool
+	}{
+		{
+			name:       "empty snapshot ID",
+			snapshotID: "",
+			expected:   &nfsSnapshot{},
+			expectErr:  true,
+		},
+		{
+			name:       "too few segments",
+			snapshotID: "test-server#base-dir#snap-uuid",
+			expected:   &nfsSnapshot{},
+			expectErr:  true,
+		},
+		{
+			name:       "too many segments",
+			snapshotID: "test-server#base-dir#snap-uuid#archive-path#archive-name#extra",
+			expected:   &nfsSnapshot{},
+			expectErr:  true,
+		},
+		{
+			name:       "valid snapshot ID",
+			snapshotID: "nfs-server.default.svc.cluster.local#share#snapshot-016f#snapshot-016f#pvc-4bcb",
+			expected: &nfsSnapshot{
+				id:      "nfs-server.default.svc.cluster.local#share#snapshot-016f#snapshot-016f#pvc-4bcb",
+				server:  "nfs-server.default.svc.cluster.local",
+				baseDir: "share",
+				uuid:    "snapshot-016f",
+				src:     "pvc-4bcb",
+			},
+			expectErr: false,
+		},
+		{
+			name:       "valid snapshot ID with nested baseDir",
+			snapshotID: "test-server#test/base/dir#snap-uuid#archive-path#archive-name",
+			expected: &nfsSnapshot{
+				id:      "test-server#test/base/dir#snap-uuid#archive-path#archive-name",
+				server:  "test-server",
+				baseDir: "test/base/dir",
+				uuid:    "snap-uuid",
+				src:     "archive-name",
+			},
+			expectErr: false,
+		},
+		{
+			name:       "baseDir with path traversal should be rejected",
+			snapshotID: "test-server#../../etc#snap-uuid#archive-path#archive-name",
+			expected:   nil,
+			expectErr:  true,
+		},
+		{
+			name:       "uuid with path traversal should be rejected",
+			snapshotID: "test-server#base-dir#../../etc/shadow#archive-path#archive-name",
+			expected:   nil,
+			expectErr:  true,
+		},
+		{
+			name:       "src with path traversal should be rejected",
+			snapshotID: "test-server#base-dir#snap-uuid#archive-path#../../etc/passwd",
+			expected:   nil,
+			expectErr:  true,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := getNfsSnapFromID(test.snapshotID)
+
+			if test.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("got %+v, expected %+v", result, test.expected)
+			}
+		})
+	}
+}

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -616,8 +616,92 @@ func TestGetInternalMountPath(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		path := getInternalMountPath(test.workingMountDir, test.vol)
+		path, err := getInternalMountPath(test.workingMountDir, test.vol)
+		assert.NoError(t, err)
 		assert.Equal(t, path, test.result)
+	}
+}
+
+// TestInternalPathContainment is a defense-in-depth check: even if a traversal
+// sequence slips past the ID/parameter validation, the internal path builders
+// must refuse to resolve a path outside workingMountDir.
+func TestInternalPathContainment(t *testing.T) {
+	cases := []struct {
+		desc      string
+		vol       *nfsVolume
+		expectErr bool
+	}{
+		{
+			desc: "clean subDir/uuid stays within base",
+			vol:  &nfsVolume{subDir: "subdir", uuid: "uuid"},
+		},
+		{
+			desc:      "uuid escapes base",
+			vol:       &nfsVolume{subDir: "subdir", uuid: "../../../etc"},
+			expectErr: true,
+		},
+		{
+			desc:      "subDir escapes base (empty uuid)",
+			vol:       &nfsVolume{subDir: "../../../etc"},
+			expectErr: true,
+		},
+		{
+			desc:      "subDir escapes base via nested traversal",
+			vol:       &nfsVolume{subDir: "a/../../../etc", uuid: "uuid"},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.desc, func(t *testing.T) {
+			_, mErr := getInternalMountPath("/tmp", test.vol)
+			_, vErr := getInternalVolumePath("/tmp", test.vol)
+			if test.expectErr {
+				// At least one builder must reject; the escaping component may be
+				// subDir (only caught by getInternalVolumePath) or uuid (caught
+				// by both).
+				assert.True(t, mErr != nil || vErr != nil, "expected containment error")
+			} else {
+				assert.NoError(t, mErr)
+				assert.NoError(t, vErr)
+			}
+		})
+	}
+}
+
+func TestNewNFSSnapshot(t *testing.T) {
+	validVol := &nfsVolume{server: "nfs-server", baseDir: "share", subDir: "subdir", uuid: "vol-uuid"}
+	cases := []struct {
+		desc      string
+		name      string
+		params    map[string]string
+		vol       *nfsVolume
+		expectErr bool
+	}{
+		{
+			desc:   "valid snapshot",
+			name:   "snap-name",
+			params: map[string]string{paramServer: "nfs-server", paramShare: "share"},
+			vol:    validVol,
+		},
+		{
+			desc:      "share with path traversal should be rejected",
+			name:      "snap-name",
+			params:    map[string]string{paramServer: "nfs-server", paramShare: "/exports/../../../etc"},
+			vol:       validVol,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := newNFSSnapshot(test.name, test.params, test.vol)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 
@@ -728,6 +812,22 @@ func TestNewNFSVolume(t *testing.T) {
 			},
 			expectVol: nil,
 			expectErr: fmt.Errorf("invalid share %q: path contains directory traversal sequence", "/exports/../../../etc"),
+		},
+		{
+			// The raw subDir template contains no "..": the traversal only
+			// appears after pvc metadata substitution, so validation must run
+			// against the expanded value.
+			desc: "subDir traversal injected via metadata substitution should be rejected",
+			name: "pv-name",
+			size: 100,
+			params: map[string]string{
+				paramServer: "//nfs-server.default.svc.cluster.local",
+				paramShare:  "share",
+				paramSubDir: fmt.Sprintf("%s/data", pvcNameMetadata),
+				pvcNameKey:  "..",
+			},
+			expectVol: nil,
+			expectErr: fmt.Errorf("invalid subDir %q: path contains directory traversal sequence", "../data"),
 		},
 	}
 

--- a/pkg/nfs/tar.go
+++ b/pkg/nfs/tar.go
@@ -205,9 +205,7 @@ func TarUnpack(srcPath, dstDirPath string, enableCompression bool) (err error) {
 
 		// Robust containment check: use filepath.Rel to prevent prefix collisions
 		// (e.g., dstDirPath="/tmp/out" vs filePath="/tmp/out2/...")
-		var rel string
-		rel, err = filepath.Rel(dstDirPath, filePath)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		if !isPathWithinBase(dstDirPath, filePath) {
 			return tar.ErrInsecurePath
 		}
 
@@ -225,8 +223,7 @@ func TarUnpack(srcPath, dstDirPath string, enableCompression bool) (err error) {
 			checkDir := parentDir
 			for checkDir != dstDirPath {
 				if realDir, evalErr := filepath.EvalSymlinks(checkDir); evalErr == nil {
-					realDirRel, relErr := filepath.Rel(dstDirPath, realDir)
-					if relErr != nil || realDirRel == ".." || strings.HasPrefix(realDirRel, ".."+string(os.PathSeparator)) || filepath.IsAbs(realDirRel) {
+					if !isPathWithinBase(dstDirPath, realDir) {
 						return tar.ErrInsecurePath
 					}
 					break

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -350,3 +350,16 @@ func validatePath(path string) error {
 	}
 	return nil
 }
+
+// isPathWithinBase reports whether path resolves to a location inside base,
+// using purely lexical analysis (filepath.Rel). It rejects paths that resolve
+// to base's parent or a sibling (rel == ".." or a "../" prefix) and absolute
+// paths. Callers that need to account for symlinks must resolve them
+// (e.g. filepath.EvalSymlinks) before calling.
+func isPathWithinBase(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return false
+	}
+	return true
+}

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -335,7 +335,15 @@ func getVolumeCapabilityFromSecret(volumeID string, secret map[string]string) *c
 }
 
 func validatePath(path string) error {
-	for _, segment := range strings.Split(path, "/") {
+	// Normalize Windows-style separators so backslash traversal (e.g. "..\..")
+	// is caught regardless of the platform the controller runs on. Use
+	// ReplaceAll rather than filepath.ToSlash, which is a no-op on Linux and so
+	// would miss backslash traversal there. Deliberately avoid filepath.Clean:
+	// it collapses trailing ".." (Clean("a/b/..") == "a"), which would drop the
+	// traversal sequence and weaken detection. See PR #1071 for the earlier
+	// Clean-based attempt that was reverted for exactly this reason.
+	normalized := strings.ReplaceAll(path, "\\", "/")
+	for _, segment := range strings.Split(normalized, "/") {
 		if segment == ".." {
 			return fmt.Errorf("path contains directory traversal sequence")
 		}

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -575,8 +575,8 @@ func TestValidatePath(t *testing.T) {
 
 		{"triple dots valid", "/home/.../data", false},
 
-		{"windows traversal", "..\\etc\\passwd", false},
-		{"mixed separators", "foo\\..\\bar", false},
+		{"windows traversal", "..\\etc\\passwd", true},
+		{"mixed separators", "foo\\..\\bar", true},
 
 		{"double slash", "foo//bar", false},
 		{"dot traversal", "./../etc", true},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `getNfsSnapFromID` utility is missing the path validation present in `getNfsVolFromID` despite being otherwise similar. Additionally, the path validation isn't as complete as it could be and missed validation in a few places.
Fix this by adding the missing path validation to `getNfsSnapFromID`, and generally improving path validation through the controller.

Note that I've considered this cleanup rather than a bug fix. Realistically none of this is "exploitable" in a real environment since they would require the creation of cluster-scoped resources (`PersistentVolume`, `VolumeSnapshotContent`, `StorageClass`, `VolumeSnapshotClass`). These are all defense in depth improvements that were identified during investigation into another issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

**Special notes for your reviewer**:

I've split this into 3 separate commits for ease of review. I could probably split the last of the commits up further if needed.

Additionally, because this is defense in depth as opposed to an actual fix, I wouldn't be offended if this was closed as Won't Fix.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
