### PR TITLE
Restrict provisioner secrets RBAC to named secrets

### DIFF
--- a/charts/latest/csi-driver-nfs/templates/rbac-csi-nfs.yaml
+++ b/charts/latest/csi-driver-nfs/templates/rbac-csi-nfs.yaml
@@ -53,9 +53,17 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # The external-provisioner sidecar only reads the optional
+  # csi.storage.k8s.io/provisioner-secret referenced by a StorageClass (used to
+  # supply mountOptions during DeleteVolume). Pinning resourceNames restricts
+  # this to secrets literally named "mount-options" instead of granting read
+  # access to every secret in the cluster, while remaining namespace-agnostic so
+  # it keeps working when provisioner-secret-namespace is templated (e.g.
+  # ${pvc.namespace}). Extend the list if you use additional secret names.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+    resourceNames: ["mount-options"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbac-csi-nfs.yaml
+++ b/deploy/rbac-csi-nfs.yaml
@@ -47,9 +47,17 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  # The external-provisioner sidecar only reads the optional
+  # csi.storage.k8s.io/provisioner-secret referenced by a StorageClass (used to
+  # supply mountOptions during DeleteVolume). Pinning resourceNames restricts
+  # this to secrets literally named "mount-options" instead of granting read
+  # access to every secret in the cluster, while remaining namespace-agnostic so
+  # it keeps working when provisioner-secret-namespace is templated (e.g.
+  # ${pvc.namespace}). Extend the list if you use additional secret names.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+    resourceNames: ["mount-options"]
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `nfs-external-provisioner-role` ClusterRole grants cluster-wide `secrets:get`. The `csi-provisioner` sidecar only uses this to read the optional `csi.storage.k8s.io/provisioner-secret` referenced by a StorageClass (to supply `mountOptions` during `DeleteVolume`); the driver itself never reads secrets from the API server. The blanket grant let the controller ServiceAccount read every secret in the cluster.

Pin the rule to `resourceNames: ["mount-options"]` so it only permits reading secrets with that name. This was chosen over a namespaced Role/RoleBinding because `resourceNames` on a ClusterRole is namespace-agnostic: it keeps working when provisioner-secret-namespace is templated per-PVC (e.g. `${pvc.namespace}`), whereas a namespaced Role would require a binding in every namespace a PVC might live in and would silently break those setups. The same change is applied to the Helm chart (charts/latest) for parity.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

**Special notes for your reviewer**:

Please see my note above RE: the alternative strategy. We might want to adopt that instead since it's arguably stronger, but it could break some users. I'm good with either.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
