### PR TITLE
feat: add uid/gid StorageClass parameters for volume directory ownership

### DIFF
--- a/deploy/example/pv-nfs-csi.yaml
+++ b/deploy/example/pv-nfs-csi.yaml
@@ -22,3 +22,5 @@ spec:
     volumeAttributes:
       server: nfs-server.default.svc.cluster.local
       share: /
+      # uid: "243"
+      # gid: "243"

--- a/deploy/example/storageclass-nfs.yaml
+++ b/deploy/example/storageclass-nfs.yaml
@@ -7,6 +7,9 @@ provisioner: nfs.csi.k8s.io
 parameters:
   server: nfs-server.default.svc.cluster.local
   share: /
+  # mountPermissions: "0770"
+  # uid: "243"
+  # gid: "243"
   # csi.storage.k8s.io/provisioner-secret is only needed for providing mountOptions in DeleteVolume
   # csi.storage.k8s.io/provisioner-secret-name: "mount-options"
   # csi.storage.k8s.io/provisioner-secret-namespace: "default"

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -10,8 +10,8 @@ server | NFS Server address | domain name `nfs-server.default.svc.cluster.local`
 share | NFS share path | `/` | Yes |
 subDir | sub directory under nfs share |  | No | if sub directory does not exist, this driver would create a new one
 mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
-uid | numeric user ID to `chown` the newly created subdirectory to. Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
-gid | numeric group ID to `chown` the newly created subdirectory to. Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+uid | numeric user ID to `chown` the newly created subdirectory to in `CreateVolume`. Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+gid | numeric group ID to `chown` the newly created subdirectory to in `CreateVolume`. Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 onDelete | when volume is deleted, keep the directory if it's `retain` | `delete`(default), `retain`, `archive`  | No | `delete`
 
  - VolumeID(`volumeHandle`) is the identifier of the volume handled by the driver, format of VolumeID:
@@ -29,8 +29,8 @@ volumeHandle | Specify a value the driver can use to uniquely identify the share
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
 volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
-volumeAttributes.uid | numeric user ID to `chown` the mount directory to. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
-volumeAttributes.gid | numeric group ID to `chown` the mount directory to. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.uid | numeric user ID to `chown` the mount directory to in `NodePublishVolume` (static PVs have no `CreateVolume`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.gid | numeric group ID to `chown` the mount directory to in `NodePublishVolume`. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 
 ### `VolumeSnapshotClass`
 
@@ -85,7 +85,17 @@ If your pods run as **non-root** and get `Permission denied` when writing to the
    > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
 
 #### When to set `uid`/`gid`
-> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` parameters run `chown` on **that subdirectory only** (not the NFS share root) after `CreateVolume` creates it, and again after `NodePublishVolume` mounts it.
+> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir. `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes.
+
+For **static PVs** there is no `CreateVolume`, so the same keys on `volumeAttributes` are applied once in `NodePublishVolume` after mount.
+
+This driver ships `fsGroupPolicy: File`. After `NodePublishVolume` returns, kubelet applies `pod.spec.securityContext.fsGroup` when it is set:
+
+- kubelet runs `chown(-1, fsGroup)` recursively: **UID is left unchanged, GID is replaced**, and the setgid bit is set
+- a pod `fsGroup` therefore **overwrites StorageClass/PV `gid`**. If you need the StorageClass `gid` to remain the group on disk, omit `fsGroup`, or set it to the same GID
+- StorageClass `uid` is not overwritten by `fsGroup`
+
+Use `uid`/`gid` when the volume directory should be owned at provision time (or at first mount for static PVs), including for pods that do not set `fsGroup`. Use `fsGroup` when kubelet should grant the pod's group write access at mount time. Do not combine them with **different** GIDs.
 
 NFS has no portable `uid=` / `gid=` mount options (unlike SMB/CIFS). This is an explicit `chown`, so the NFS export must allow it (`no_root_squash`, or a squash uid that is allowed to own the path). Root-squashed exports typically leave the directory owned by `nobody` and provisioning or mount will fail if `uid`/`gid` cannot be applied.
 
@@ -101,8 +111,6 @@ parameters:
 Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers.
 
 These are StorageClass (or static PV `volumeAttributes`) parameters. The PVC API has no owner fields; CSI only forwards StorageClass parameters. One StorageClass per tenant uid is the supported pattern today.
-
-`securityContext.fsGroup` remains the Kubernetes-native way to grant the **pod** group write access at mount time and can still run after this `chown`.
 
 #### `subDir` parameter supports following pv/pvc metadata conversion
 > if `subDir` value contains following strings, it would be converted into corresponding pv/pvc name or namespace

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -29,8 +29,8 @@ volumeHandle | Specify a value the driver can use to uniquely identify the share
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
 volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
-volumeAttributes.uid | numeric user ID to `chown` the mount directory to in `NodePublishVolume` (static PVs have no `CreateVolume`; Linux only). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
-volumeAttributes.gid | numeric group ID to `chown` the mount directory to in `NodePublishVolume` (Linux only). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
+volumeAttributes.uid | numeric user ID to `chown` the mount directory to in writable `NodePublishVolume` (static PVs have no `CreateVolume`; Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.gid | numeric group ID to `chown` the mount directory to in writable `NodePublishVolume` (Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 
 ### `VolumeSnapshotClass`
 
@@ -85,7 +85,7 @@ If your pods run as **non-root** and get `Permission denied` when writing to the
    > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
 
 #### When to set `uid`/`gid`
-> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir (and after clone/snapshot copy, so `cp -a` / tar cannot restore the source owner). `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes. `uid`/`gid` are Linux-only; setting them on Windows returns an error.
+> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir (and after clone/snapshot copy, so `cp -a` / tar cannot restore the source owner). `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes. `uid`/`gid` are Linux-only: `CreateVolume` and writable static publishes return an error on Windows; read-only static publishes skip `chown` and succeed.
 
 For **static PVs** there is no `CreateVolume`, so the same keys on `volumeAttributes` are applied in `NodePublishVolume` after mount (including retries when the target is already mounted). Read-only publishes skip `chown`.
 

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -10,6 +10,8 @@ server | NFS Server address | domain name `nfs-server.default.svc.cluster.local`
 share | NFS share path | `/` | Yes |
 subDir | sub directory under nfs share |  | No | if sub directory does not exist, this driver would create a new one
 mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+uid | numeric user ID to `chown` the newly created subdirectory to. Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+gid | numeric group ID to `chown` the newly created subdirectory to. Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
 onDelete | when volume is deleted, keep the directory if it's `retain` | `delete`(default), `retain`, `archive`  | No | `delete`
 
  - VolumeID(`volumeHandle`) is the identifier of the volume handled by the driver, format of VolumeID:
@@ -27,6 +29,8 @@ volumeHandle | Specify a value the driver can use to uniquely identify the share
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
 volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+volumeAttributes.uid | numeric user ID to `chown` the mount directory to. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.gid | numeric group ID to `chown` the mount directory to. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
 
 ### `VolumeSnapshotClass`
 
@@ -79,6 +83,26 @@ If your pods run as **non-root** and get `Permission denied` when writing to the
            mountPermissions: "0777"
      ```
    > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
+
+#### When to set `uid`/`gid`
+> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` parameters run `chown` on **that subdirectory only** (not the NFS share root) after `CreateVolume` creates it, and again after `NodePublishVolume` mounts it.
+
+NFS has no portable `uid=` / `gid=` mount options (unlike SMB/CIFS). This is an explicit `chown`, so the NFS export must allow it (`no_root_squash`, or a squash uid that is allowed to own the path). Root-squashed exports typically leave the directory owned by `nobody` and provisioning or mount will fail if `uid`/`gid` cannot be applied.
+
+```yaml
+parameters:
+  server: nfs-server.default.svc.cluster.local
+  share: /
+  mountPermissions: "0770"
+  uid: "243"
+  gid: "243"
+```
+
+Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers.
+
+These are StorageClass (or static PV `volumeAttributes`) parameters. The PVC API has no owner fields; CSI only forwards StorageClass parameters. One StorageClass per tenant uid is the supported pattern today.
+
+`securityContext.fsGroup` remains the Kubernetes-native way to grant the **pod** group write access at mount time and can still run after this `chown`.
 
 #### `subDir` parameter supports following pv/pvc metadata conversion
 > if `subDir` value contains following strings, it would be converted into corresponding pv/pvc name or namespace

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -10,8 +10,8 @@ server | NFS Server address | domain name `nfs-server.default.svc.cluster.local`
 share | NFS share path | `/` | Yes |
 subDir | sub directory under nfs share |  | No | if sub directory does not exist, this driver would create a new one
 mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
-uid | numeric user ID to `chown` the newly created subdirectory to in `CreateVolume`. Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
-gid | numeric group ID to `chown` the newly created subdirectory to in `CreateVolume`. Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
+uid | numeric user ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+gid | numeric group ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 onDelete | when volume is deleted, keep the directory if it's `retain` | `delete`(default), `retain`, `archive`  | No | `delete`
 
  - VolumeID(`volumeHandle`) is the identifier of the volume handled by the driver, format of VolumeID:
@@ -29,8 +29,8 @@ volumeHandle | Specify a value the driver can use to uniquely identify the share
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
 volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
-volumeAttributes.uid | numeric user ID to `chown` the mount directory to in `NodePublishVolume` (static PVs have no `CreateVolume`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
-volumeAttributes.gid | numeric group ID to `chown` the mount directory to in `NodePublishVolume`. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
+volumeAttributes.uid | numeric user ID to `chown` the mount directory to in `NodePublishVolume` (static PVs have no `CreateVolume`; Linux only). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.gid | numeric group ID to `chown` the mount directory to in `NodePublishVolume` (Linux only). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 
 ### `VolumeSnapshotClass`
 
@@ -85,9 +85,9 @@ If your pods run as **non-root** and get `Permission denied` when writing to the
    > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
 
 #### When to set `uid`/`gid`
-> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir. `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes.
+> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir (and after clone/snapshot copy, so `cp -a` / tar cannot restore the source owner). `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes. `uid`/`gid` are Linux-only; setting them on Windows returns an error.
 
-For **static PVs** there is no `CreateVolume`, so the same keys on `volumeAttributes` are applied once in `NodePublishVolume` after mount.
+For **static PVs** there is no `CreateVolume`, so the same keys on `volumeAttributes` are applied in `NodePublishVolume` after mount (including retries when the target is already mounted). Read-only publishes skip `chown`.
 
 This driver ships `fsGroupPolicy: File`. After `NodePublishVolume` returns, kubelet applies `pod.spec.securityContext.fsGroup` when it is set:
 

--- a/pkg/nfs/chmod_unix.go
+++ b/pkg/nfs/chmod_unix.go
@@ -45,5 +45,7 @@ func fileOwner(path string) (int, int, error) {
 }
 
 func chownPath(path string, uid, gid int) error {
-	return os.Chown(path, uid, gid)
+	// Lchown matches fileOwner's Lstat: do not follow a symlink to a
+	// different inode than the path we inspected.
+	return os.Lchown(path, uid, gid)
 }

--- a/pkg/nfs/chmod_unix.go
+++ b/pkg/nfs/chmod_unix.go
@@ -19,11 +19,31 @@ limitations under the License.
 
 package nfs
 
-import "syscall"
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
 
 // chmod uses syscall.Chmod to correctly handle setuid/setgid/sticky bits
 // (e.g. 02770), since os.Chmod maps os.FileMode bits differently from raw
 // Unix mode bits.
 func chmod(path string, mode uint32) error {
 	return syscall.Chmod(path, mode)
+}
+
+func fileOwner(path string) (int, int, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return unsetOwner, unsetOwner, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return unsetOwner, unsetOwner, fmt.Errorf("failed to get uid/gid for %s", path)
+	}
+	return int(stat.Uid), int(stat.Gid), nil
+}
+
+func chownPath(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
 }

--- a/pkg/nfs/chmod_unix_test.go
+++ b/pkg/nfs/chmod_unix_test.go
@@ -84,3 +84,30 @@ func TestChmodIfPermissionMismatchSpecialBits(t *testing.T) {
 		})
 	}
 }
+
+func TestChownIfOwnerMismatch(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := dir + "/testdir"
+	if err := os.Mkdir(targetPath, 0777); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+
+	if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
+		t.Fatalf("chownIfOwnerMismatch to current owner failed: %v", err)
+	}
+
+	if err := chownIfOwnerMismatch(targetPath, unsetOwner, unsetOwner); err != nil {
+		t.Fatalf("chownIfOwnerMismatch with both unset failed: %v", err)
+	}
+
+	gotUID, gotGID, err := fileOwner(targetPath)
+	if err != nil {
+		t.Fatalf("fileOwner failed: %v", err)
+	}
+	if gotUID != uid || gotGID != gid {
+		t.Errorf("expected owner %d:%d, got %d:%d", uid, gid, gotUID, gotGID)
+	}
+}

--- a/pkg/nfs/chmod_unix_test.go
+++ b/pkg/nfs/chmod_unix_test.go
@@ -95,6 +95,9 @@ func TestChownIfOwnerMismatch(t *testing.T) {
 	uid := os.Getuid()
 	gid := os.Getgid()
 
+	// Same-owner call only exercises the skip path. Mutation and one-sided
+	// unsetOwner behavior are covered by TestChownIfOwnerMismatchInjected in utils_test.go
+	// (injected fileOwner/chownPath, no root required).
 	if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
 		t.Fatalf("chownIfOwnerMismatch to current owner failed: %v", err)
 	}

--- a/pkg/nfs/chmod_windows.go
+++ b/pkg/nfs/chmod_windows.go
@@ -19,7 +19,10 @@ limitations under the License.
 
 package nfs
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // chmod falls back to os.Chmod on Windows, which does not support
 // setuid/setgid/sticky bits but avoids a build failure.
@@ -34,6 +37,9 @@ func fileOwner(path string) (int, int, error) {
 	return unsetOwner, unsetOwner, nil
 }
 
-func chownPath(_ string, _, _ int) error {
-	return nil
+func chownPath(_ string, uid, gid int) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	return fmt.Errorf("uid/gid is not supported on Windows")
 }

--- a/pkg/nfs/chmod_windows.go
+++ b/pkg/nfs/chmod_windows.go
@@ -26,3 +26,14 @@ import "os"
 func chmod(path string, mode uint32) error {
 	return os.Chmod(path, os.FileMode(mode))
 }
+
+func fileOwner(path string) (int, int, error) {
+	if _, err := os.Lstat(path); err != nil {
+		return unsetOwner, unsetOwner, err
+	}
+	return unsetOwner, unsetOwner, nil
+}
+
+func chownPath(_ string, _, _ int) error {
+	return nil
+}

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -127,6 +127,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	mountPermissions := cs.Driver.mountPermissions
+	uid, gid := unsetOwner, unsetOwner
 	reqCapacity := req.GetCapacityRange().GetRequiredBytes()
 	parameters := req.GetParameters()
 	if parameters == nil {
@@ -148,6 +149,20 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 				var err error
 				if mountPermissions, err = strconv.ParseUint(v, 8, 32); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid mountPermissions %s in storage class", v)
+				}
+			}
+		case paramUID:
+			{
+				var err error
+				if uid, err = parseOwnerID(paramUID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
+				}
+			}
+		case paramGID:
+			{
+				var err error
+				if gid, err = parseOwnerID(paramGID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
 				}
 			}
 		default:
@@ -193,6 +208,10 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if err := chmodIfPermissionMismatch(internalVolumePath, uint32(mountPermissions)); err != nil {
 			klog.Warningf("failed to chmod subdirectory: %v", err)
 		}
+	}
+
+	if err := chownIfOwnerMismatch(internalVolumePath, uid, gid); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to chown subdirectory: %v", err)
 	}
 
 	if req.GetVolumeContentSource() != nil {
@@ -524,9 +543,11 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 	for k, v := range volumeContext {
 		// don't set subDir, server, or share fields: only nfs-server:/share
 		// should be mounted via the volume's own values across all internal
-		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.)
+		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.).
+		// uid/gid must also be omitted: NodePublishVolume would otherwise
+		// chown the NFS share root instead of the new subdirectory.
 		switch strings.ToLower(k) {
-		case paramSubDir, paramServer, paramShare:
+		case paramSubDir, paramServer, paramShare, paramUID, paramGID:
 			continue
 		default:
 			volContext[k] = v

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -544,8 +544,8 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 		// don't set subDir, server, or share fields: only nfs-server:/share
 		// should be mounted via the volume's own values across all internal
 		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.).
-		// uid/gid must also be omitted: NodePublishVolume would otherwise
-		// chown the NFS share root instead of the new subdirectory.
+		// uid/gid must also be omitted: NodePublishVolume still chowns
+		// static PVs and would otherwise chown the NFS share root.
 		switch strings.ToLower(k) {
 		case paramSubDir, paramServer, paramShare, paramUID, paramGID:
 			continue

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -210,14 +210,16 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	if err := chownIfOwnerMismatch(internalVolumePath, uid, gid); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to chown subdirectory: %v", err)
-	}
-
 	if req.GetVolumeContentSource() != nil {
 		if err := cs.copyVolume(ctx, req, nfsVol); err != nil {
 			return nil, err
 		}
+	}
+
+	// Apply after copyVolume: cp -a / tar restore can overwrite the
+	// destination directory's owner with the source metadata.
+	if err := chownIfOwnerMismatch(internalVolumePath, uid, gid); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to chown subdirectory: %v", err)
 	}
 
 	setKeyValueInMap(parameters, paramSubDir, nfsVol.subDir)

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -216,6 +216,84 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "valid uid and gid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    fmt.Sprintf("%d", os.Getuid()),
+					paramGID:    fmt.Sprintf("%d", os.Getgid()),
+				},
+			},
+			resp: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					VolumeId: newTestVolumeID,
+					VolumeContext: map[string]string{
+						paramServer: testServer,
+						paramShare:  testBaseDir,
+						paramSubDir: testCSIVolume,
+						paramUID:    fmt.Sprintf("%d", os.Getuid()),
+						paramGID:    fmt.Sprintf("%d", os.Getgid()),
+					},
+				},
+			},
+		},
+		{
+			name: "[Error] invalid uid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    "abc",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "[Error] invalid gid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramGID:    "-1",
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -235,8 +235,8 @@ func TestCreateVolume(t *testing.T) {
 				Parameters: map[string]string{
 					paramServer: testServer,
 					paramShare:  testBaseDir,
-					paramUID:    "243",
-					paramGID:    "243",
+					paramUID:    testOwnerID(),
+					paramGID:    testOwnerID(),
 				},
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -246,8 +246,8 @@ func TestCreateVolume(t *testing.T) {
 						paramServer: testServer,
 						paramShare:  testBaseDir,
 						paramSubDir: testCSIVolume,
-						paramUID:    "243",
-						paramGID:    "243",
+						paramUID:    testOwnerID(),
+						paramGID:    testOwnerID(),
 					},
 				},
 			},

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -86,10 +86,12 @@ func TestMain(m *testing.M) {
 
 func TestCreateVolume(t *testing.T) {
 	cases := []struct {
-		name      string
-		req       *csi.CreateVolumeRequest
-		resp      *csi.CreateVolumeResponse
-		expectErr bool
+		name          string
+		req           *csi.CreateVolumeRequest
+		resp          *csi.CreateVolumeResponse
+		expectErr     bool
+		skipOnWindows bool
+		windowsOnly   bool
 	}{
 		{
 			name: "valid defaults",
@@ -233,8 +235,8 @@ func TestCreateVolume(t *testing.T) {
 				Parameters: map[string]string{
 					paramServer: testServer,
 					paramShare:  testBaseDir,
-					paramUID:    fmt.Sprintf("%d", os.Getuid()),
-					paramGID:    fmt.Sprintf("%d", os.Getgid()),
+					paramUID:    "243",
+					paramGID:    "243",
 				},
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -244,11 +246,36 @@ func TestCreateVolume(t *testing.T) {
 						paramServer: testServer,
 						paramShare:  testBaseDir,
 						paramSubDir: testCSIVolume,
-						paramUID:    fmt.Sprintf("%d", os.Getuid()),
-						paramGID:    fmt.Sprintf("%d", os.Getgid()),
+						paramUID:    "243",
+						paramGID:    "243",
 					},
 				},
 			},
+			skipOnWindows: true,
+		},
+		{
+			name: "[Error] uid/gid not supported on Windows",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    "243",
+					paramGID:    "243",
+				},
+			},
+			expectErr:   true,
+			windowsOnly: true,
 		},
 		{
 			name: "[Error] invalid uid",
@@ -298,6 +325,12 @@ func TestCreateVolume(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" && test.skipOnWindows {
+				t.Skip("uid/gid chown is not supported on Windows")
+			}
+			if runtime.GOOS != "windows" && test.windowsOnly {
+				t.Skip("Windows-only")
+			}
 			// Setup
 			cs := initTestController(t)
 			// Run

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -235,8 +235,8 @@ func TestCreateVolume(t *testing.T) {
 				Parameters: map[string]string{
 					paramServer: testServer,
 					paramShare:  testBaseDir,
-					paramUID:    testOwnerID(),
-					paramGID:    testOwnerID(),
+					paramUID:    testOwnerUID(),
+					paramGID:    testOwnerGID(),
 				},
 			},
 			resp: &csi.CreateVolumeResponse{
@@ -246,8 +246,8 @@ func TestCreateVolume(t *testing.T) {
 						paramServer: testServer,
 						paramShare:  testBaseDir,
 						paramSubDir: testCSIVolume,
-						paramUID:    testOwnerID(),
-						paramGID:    testOwnerID(),
+						paramUID:    testOwnerUID(),
+						paramGID:    testOwnerGID(),
 					},
 				},
 			},

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -83,9 +83,12 @@ const (
 	pvcNameKey            = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey       = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey             = "csi.storage.k8s.io/pv/name"
-	pvcNameMetadata       = "${pvc.metadata.name}"
-	pvcNamespaceMetadata  = "${pvc.metadata.namespace}"
-	pvNameMetadata        = "${pv.metadata.name}"
+	// csiProvisionerIdentityKey is added to dynamically provisioned PVs by
+	// external-provisioner. Presence means CreateVolume already ran.
+	csiProvisionerIdentityKey = "storage.kubernetes.io/csiProvisionerIdentity"
+	pvcNameMetadata           = "${pvc.metadata.name}"
+	pvcNamespaceMetadata      = "${pvc.metadata.namespace}"
+	pvNameMetadata            = "${pv.metadata.name}"
 )
 
 func NewDriver(options *DriverOptions) *Driver {

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -78,6 +78,8 @@ const (
 	paramOnDelete         = "ondelete"
 	mountOptionsField     = "mountoptions"
 	mountPermissionsField = "mountpermissions"
+	paramUID              = "uid"
+	paramGID              = "gid"
 	pvcNameKey            = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey       = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey             = "csi.storage.k8s.io/pv/name"

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -76,6 +76,7 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
+	uid, gid := unsetOwner, unsetOwner
 	for k, v := range req.GetVolumeContext() {
 		switch strings.ToLower(k) {
 		case paramServer:
@@ -99,6 +100,20 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 				var err error
 				if mountPermissions, err = strconv.ParseUint(v, 8, 32); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid mountPermissions %s", v)
+				}
+			}
+		case paramUID:
+			{
+				var err error
+				if uid, err = parseOwnerID(paramUID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
+				}
+			}
+		case paramGID:
+			{
+				var err error
+				if gid, err = parseOwnerID(paramGID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
 				}
 			}
 		}
@@ -173,6 +188,10 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 		}
 	} else {
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mountPermissions is set as 0", targetPath)
+	}
+
+	if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	klog.V(2).Infof("volume(%s) mount %s on %s succeeded", volumeID, source, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -190,8 +190,16 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mountPermissions is set as 0", targetPath)
 	}
 
-	if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	// Dynamic volumes are chowned in CreateVolume. Re-applying here is
+	// redundant and, with fsGroupPolicy: File, kubelet still overwrites gid
+	// after this RPC if the pod sets fsGroup. Static PVs have no CreateVolume,
+	// so apply uid/gid once after mount.
+	if uid != unsetOwner || gid != unsetOwner {
+		if isDynamicallyProvisioned(req.GetVolumeContext()) {
+			klog.V(2).Infof("skip chown on targetPath(%s): uid/gid already applied in CreateVolume", targetPath)
+		} else if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 	klog.V(2).Infof("volume(%s) mount %s on %s succeeded", volumeID, source, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -161,6 +161,9 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 			}
 			// fall through to remount
 		} else {
+			if err := ns.applyUIDGID(targetPath, uid, gid, req.GetReadonly(), req.GetVolumeContext()); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 	}
@@ -190,19 +193,29 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mountPermissions is set as 0", targetPath)
 	}
 
-	// Dynamic volumes are chowned in CreateVolume. Re-applying here is
-	// redundant and, with fsGroupPolicy: File, kubelet still overwrites gid
-	// after this RPC if the pod sets fsGroup. Static PVs have no CreateVolume,
-	// so apply uid/gid once after mount.
-	if uid != unsetOwner || gid != unsetOwner {
-		if isDynamicallyProvisioned(req.GetVolumeContext()) {
-			klog.V(2).Infof("skip chown on targetPath(%s): uid/gid already applied in CreateVolume", targetPath)
-		} else if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
-		}
+	if err := ns.applyUIDGID(targetPath, uid, gid, req.GetReadonly(), req.GetVolumeContext()); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 	klog.V(2).Infof("volume(%s) mount %s on %s succeeded", volumeID, source, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+// applyUIDGID chowns static PVs after mount. Dynamic volumes are already
+// owned in CreateVolume. Skip read-only publishes: the mount is ro so chown
+// would fail.
+func (ns *NodeServer) applyUIDGID(targetPath string, uid, gid int, readonly bool, volumeContext map[string]string) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	if readonly {
+		klog.V(2).Infof("skip chown on targetPath(%s): volume is read-only", targetPath)
+		return nil
+	}
+	if isDynamicallyProvisioned(volumeContext) {
+		klog.V(2).Infof("skip chown on targetPath(%s): uid/gid already applied in CreateVolume", targetPath)
+		return nil
+	}
+	return chownIfOwnerMismatch(targetPath, uid, gid)
 }
 
 // NodeUnpublishVolume unmount the volume

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -67,6 +67,19 @@ func TestNodePublishVolume(t *testing.T) {
 		mountPermissionsField: "07ab",
 	}
 
+	paramsWithOwner := map[string]string{
+		"server":  "server",
+		"share":   "share",
+		paramUID: fmt.Sprintf("%d", os.Getuid()),
+		paramGID: fmt.Sprintf("%d", os.Getgid()),
+	}
+
+	invalidUIDParams := map[string]string{
+		"server":  "server",
+		"share":   "share",
+		paramUID: "abc",
+	}
+
 	volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
 	alreadyMountedTarget := testutil.GetWorkDirPath("false_is_likely_exist_target", t)
 	targetTest := testutil.GetWorkDirPath("target_test", t)
@@ -178,6 +191,26 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetTest,
 				Readonly:         true},
 			expectedErr: status.Error(codes.InvalidArgument, "invalid mountPermissions 07ab"),
+		},
+		{
+			desc: "[Success] Valid request with uid and gid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwner,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: nil,
+		},
+		{
+			desc: "[Error] invalid uid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    invalidUIDParams,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: status.Error(codes.InvalidArgument, "invalid uid abc"),
 		},
 		{
 			desc: "[Success] Stale mount detected and remounted",

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -84,6 +84,14 @@ func TestNodePublishVolume(t *testing.T) {
 		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
 	}
 
+	paramsWithOwnerStaticPVName := map[string]string{
+		"server":  "server",
+		"share":   "share",
+		paramUID:  testOwnerUID(),
+		paramGID:  testOwnerGID(),
+		pvNameKey: "pvname",
+	}
+
 	invalidUIDParams := map[string]string{
 		"server": "server",
 		"share":  "share",
@@ -231,6 +239,16 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetTest,
 				Readonly:         true},
 			expectedErr: nil,
+		},
+		{
+			desc: "[Success] Static PV with pv name metadata still applies uid and gid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwnerStaticPVName,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       alreadyMountedTarget},
+			skipOnWindows: true,
+			expectedErr:   nil,
 		},
 		{
 			desc: "[Error] invalid uid",

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -68,15 +68,24 @@ func TestNodePublishVolume(t *testing.T) {
 	}
 
 	paramsWithOwner := map[string]string{
-		"server":  "server",
-		"share":   "share",
+		"server": "server",
+		"share":  "share",
 		paramUID: fmt.Sprintf("%d", os.Getuid()),
 		paramGID: fmt.Sprintf("%d", os.Getgid()),
 	}
 
+	paramsWithOwnerDynamic := map[string]string{
+		"server":                  "server",
+		"share":                   "share",
+		paramUID:                  fmt.Sprintf("%d", os.Getuid()),
+		paramGID:                  fmt.Sprintf("%d", os.Getgid()),
+		pvNameKey:                 "pvname",
+		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
+	}
+
 	invalidUIDParams := map[string]string{
-		"server":  "server",
-		"share":   "share",
+		"server": "server",
+		"share":  "share",
 		paramUID: "abc",
 	}
 
@@ -196,6 +205,16 @@ func TestNodePublishVolume(t *testing.T) {
 			desc: "[Success] Valid request with uid and gid",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeContext:    paramsWithOwner,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: nil,
+		},
+		{
+			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwnerDynamic,
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:         "vol_1",
 				TargetPath:       targetTest,

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -71,15 +71,15 @@ func TestNodePublishVolume(t *testing.T) {
 	paramsWithOwner := map[string]string{
 		"server": "server",
 		"share":  "share",
-		paramUID: "243",
-		paramGID: "243",
+		paramUID: testOwnerID(),
+		paramGID: testOwnerID(),
 	}
 
 	paramsWithOwnerDynamic := map[string]string{
 		"server":                  "server",
 		"share":                   "share",
-		paramUID:                  "243",
-		paramGID:                  "243",
+		paramUID:                  testOwnerID(),
+		paramGID:                  testOwnerID(),
 		pvNameKey:                 "pvname",
 		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
 	}

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -71,15 +71,15 @@ func TestNodePublishVolume(t *testing.T) {
 	paramsWithOwner := map[string]string{
 		"server": "server",
 		"share":  "share",
-		paramUID: testOwnerID(),
-		paramGID: testOwnerID(),
+		paramUID: testOwnerUID(),
+		paramGID: testOwnerGID(),
 	}
 
 	paramsWithOwnerDynamic := map[string]string{
 		"server":                  "server",
 		"share":                   "share",
-		paramUID:                  testOwnerID(),
-		paramGID:                  testOwnerID(),
+		paramUID:                  testOwnerUID(),
+		paramGID:                  testOwnerGID(),
 		pvNameKey:                 "pvname",
 		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
 	}

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -212,6 +212,15 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			desc: "[Success] Already mounted static PV with uid and gid still applies owner",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwner,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       alreadyMountedTarget},
+			expectedErr: nil,
+		},
+		{
 			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
 			req: &csi.NodePublishVolumeRequest{
 				VolumeContext:    paramsWithOwnerDynamic,

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -70,15 +71,15 @@ func TestNodePublishVolume(t *testing.T) {
 	paramsWithOwner := map[string]string{
 		"server": "server",
 		"share":  "share",
-		paramUID: fmt.Sprintf("%d", os.Getuid()),
-		paramGID: fmt.Sprintf("%d", os.Getgid()),
+		paramUID: "243",
+		paramGID: "243",
 	}
 
 	paramsWithOwnerDynamic := map[string]string{
 		"server":                  "server",
 		"share":                   "share",
-		paramUID:                  fmt.Sprintf("%d", os.Getuid()),
-		paramGID:                  fmt.Sprintf("%d", os.Getgid()),
+		paramUID:                  "243",
+		paramGID:                  "243",
 		pvNameKey:                 "pvname",
 		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
 	}
@@ -218,7 +219,8 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:         "vol_1",
 				TargetPath:       alreadyMountedTarget},
-			expectedErr: nil,
+			skipOnWindows: true,
+			expectedErr:   nil,
 		},
 		{
 			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
@@ -265,6 +267,9 @@ func TestNodePublishVolume(t *testing.T) {
 	_ = makeDir(targetTest)
 
 	for _, tc := range tests {
+		if runtime.GOOS == "windows" && tc.skipOnWindows {
+			continue
+		}
 		if tc.setup != nil {
 			tc.setup()
 		}

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -42,7 +42,7 @@ const (
 	retain                          = "retain"
 	archive                         = "archive"
 	volumeOperationAlreadyExistsFmt = "An operation with the given Volume ID %s already exists"
-	// unsetOwner is passed to os.Chown to leave uid or gid unchanged.
+	// unsetOwner is passed to os.Lchown to leave uid or gid unchanged.
 	unsetOwner = -1
 )
 
@@ -214,10 +214,11 @@ func chmodIfPermissionMismatch(targetPath string, mode uint32) error {
 
 // isDynamicallyProvisioned reports whether volumeContext belongs to a PV
 // created by the CSI provisioner (CreateVolume already applied uid/gid).
+// Only csiProvisionerIdentityKey is used: pvNameKey is also a documented
+// static PV attribute for ${pv.metadata.name} subDir substitution.
 func isDynamicallyProvisioned(volumeContext map[string]string) bool {
 	for k := range volumeContext {
-		switch strings.ToLower(k) {
-		case pvNameKey, strings.ToLower(csiProvisionerIdentityKey):
+		if strings.EqualFold(k, csiProvisionerIdentityKey) {
 			return true
 		}
 	}
@@ -239,7 +240,7 @@ func parseOwnerID(field, value string) (int, error) {
 
 // chownIfOwnerMismatch only performs chown when uid/gid are set and the
 // current owner does not already match. uid or gid may be unsetOwner (-1) to
-// leave that ID unchanged, matching os.Chown.
+// leave that ID unchanged, matching os.Lchown.
 func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
 	if uid == unsetOwner && gid == unsetOwner {
 		return nil
@@ -259,7 +260,7 @@ func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
 		klog.V(2).Infof("skip chown on targetPath(%s) since owner is already %d:%d", targetPath, currentUID, currentGID)
 		return nil
 	}
-	// Pass the original uid/gid (possibly unsetOwner / -1) so os.Chown
+	// Pass the original uid/gid (possibly unsetOwner / -1) so os.Lchown
 	// leaves an omitted ID unchanged atomically.
 	klog.V(2).Infof("chown targetPath(%s, current %d:%d) to %d:%d", targetPath, currentUID, currentGID, uid, gid)
 	return chownPathFn(targetPath, uid, gid)

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -205,6 +205,18 @@ func chmodIfPermissionMismatch(targetPath string, mode uint32) error {
 	return nil
 }
 
+// isDynamicallyProvisioned reports whether volumeContext belongs to a PV
+// created by the CSI provisioner (CreateVolume already applied uid/gid).
+func isDynamicallyProvisioned(volumeContext map[string]string) bool {
+	for k := range volumeContext {
+		switch strings.ToLower(k) {
+		case pvNameKey, strings.ToLower(csiProvisionerIdentityKey):
+			return true
+		}
+	}
+	return false
+}
+
 // parseOwnerID parses an optional numeric uid/gid StorageClass parameter.
 // An empty value means "leave this ID unchanged".
 func parseOwnerID(field, value string) (int, error) {

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +42,8 @@ const (
 	retain                          = "retain"
 	archive                         = "archive"
 	volumeOperationAlreadyExistsFmt = "An operation with the given Volume ID %s already exists"
+	// unsetOwner is passed to os.Chown to leave uid or gid unchanged.
+	unsetOwner = -1
 )
 
 var supportedOnDeleteValues = []string{"", delete, retain, archive}
@@ -200,6 +203,45 @@ func chmodIfPermissionMismatch(targetPath string, mode uint32) error {
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mode is already 0%o", targetPath, mode)
 	}
 	return nil
+}
+
+// parseOwnerID parses an optional numeric uid/gid StorageClass parameter.
+// An empty value means "leave this ID unchanged".
+func parseOwnerID(field, value string) (int, error) {
+	if value == "" {
+		return unsetOwner, nil
+	}
+	id, err := strconv.ParseInt(value, 10, 32)
+	if err != nil || id < 0 {
+		return unsetOwner, fmt.Errorf("invalid %s %s", field, value)
+	}
+	return int(id), nil
+}
+
+// chownIfOwnerMismatch only performs chown when uid/gid are set and the
+// current owner does not already match. uid or gid may be unsetOwner (-1) to
+// leave that ID unchanged, matching os.Chown.
+func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	currentUID, currentGID, err := fileOwner(targetPath)
+	if err != nil {
+		return err
+	}
+	wantUID, wantGID := uid, gid
+	if uid == unsetOwner {
+		wantUID = currentUID
+	}
+	if gid == unsetOwner {
+		wantGID = currentGID
+	}
+	if currentUID == wantUID && currentGID == wantGID {
+		klog.V(2).Infof("skip chown on targetPath(%s) since owner is already %d:%d", targetPath, currentUID, currentGID)
+		return nil
+	}
+	klog.V(2).Infof("chown targetPath(%s, current %d:%d) to %d:%d", targetPath, currentUID, currentGID, wantUID, wantGID)
+	return chownPath(targetPath, wantUID, wantGID)
 }
 
 // getServerFromSource if server is IPv6, return [IPv6]

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -48,6 +48,13 @@ const (
 
 var supportedOnDeleteValues = []string{"", delete, retain, archive}
 
+// fileOwnerFn and chownPathFn are overridden in tests to cover one-sided
+// uid/gid updates without requiring root.
+var (
+	fileOwnerFn = fileOwner
+	chownPathFn = chownPath
+)
+
 func validateOnDeleteValue(onDelete string) error {
 	for _, v := range supportedOnDeleteValues {
 		if strings.EqualFold(v, onDelete) {
@@ -237,7 +244,7 @@ func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
 	if uid == unsetOwner && gid == unsetOwner {
 		return nil
 	}
-	currentUID, currentGID, err := fileOwner(targetPath)
+	currentUID, currentGID, err := fileOwnerFn(targetPath)
 	if err != nil {
 		return err
 	}
@@ -252,8 +259,10 @@ func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
 		klog.V(2).Infof("skip chown on targetPath(%s) since owner is already %d:%d", targetPath, currentUID, currentGID)
 		return nil
 	}
-	klog.V(2).Infof("chown targetPath(%s, current %d:%d) to %d:%d", targetPath, currentUID, currentGID, wantUID, wantGID)
-	return chownPath(targetPath, wantUID, wantGID)
+	// Pass the original uid/gid (possibly unsetOwner / -1) so os.Chown
+	// leaves an omitted ID unchanged atomically.
+	klog.V(2).Infof("chown targetPath(%s, current %d:%d) to %d:%d", targetPath, currentUID, currentGID, uid, gid)
+	return chownPathFn(targetPath, uid, gid)
 }
 
 // getServerFromSource if server is IPv6, return [IPv6]

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -149,6 +149,41 @@ func TestParseOwnerID(t *testing.T) {
 	}
 }
 
+func TestIsDynamicallyProvisioned(t *testing.T) {
+	tests := []struct {
+		desc     string
+		ctx      map[string]string
+		expected bool
+	}{
+		{
+			desc:     "nil context",
+			expected: false,
+		},
+		{
+			desc:     "static PV attributes",
+			ctx:      map[string]string{"server": "nfs", "share": "/", paramUID: "243"},
+			expected: false,
+		},
+		{
+			desc:     "provisioner identity",
+			ctx:      map[string]string{csiProvisionerIdentityKey: "nfs.csi.k8s.io"},
+			expected: true,
+		},
+		{
+			desc:     "pv name injected by provisioner",
+			ctx:      map[string]string{pvNameKey: "pvc-123"},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if got := isDynamicallyProvisioned(test.ctx); got != test.expected {
+				t.Errorf("got %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
 func TestGetLogLevel(t *testing.T) {
 	tests := []struct {
 		method string

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,16 @@ var (
 	invalidEndpoint = "invalid-endpoint"
 	emptyAddr       = "tcp://"
 )
+
+// testOwnerID is a uid/gid string parseOwnerID accepts. On Unix it is the
+// current process ID so chownIfOwnerMismatch is a no-op without root. On
+// Windows Getuid is -1 (invalid); tests that actually chown must skip.
+func testOwnerID() string {
+	if uid := os.Getuid(); uid >= 0 {
+		return strconv.Itoa(uid)
+	}
+	return "243"
+}
 
 func TestParseEndpoint(t *testing.T) {
 	cases := []struct {

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -238,9 +238,9 @@ func TestIsDynamicallyProvisioned(t *testing.T) {
 			expected: true,
 		},
 		{
-			desc:     "pv name injected by provisioner",
-			ctx:      map[string]string{pvNameKey: "pvc-123"},
-			expected: true,
+			desc:     "pv name alone is not dynamic (static subDir metadata)",
+			ctx:      map[string]string{pvNameKey: "pvc-123", paramUID: "243"},
+			expected: false,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -34,12 +34,20 @@ var (
 	emptyAddr       = "tcp://"
 )
 
-// testOwnerID is a uid/gid string parseOwnerID accepts. On Unix it is the
-// current process ID so chownIfOwnerMismatch is a no-op without root. On
-// Windows Getuid is -1 (invalid); tests that actually chown must skip.
-func testOwnerID() string {
+// testOwnerUID/testOwnerGID are uid/gid strings parseOwnerID accepts.
+// On Unix they match the process so chownIfOwnerMismatch is a no-op without
+// root. Using uid for both would try to change the group (often EPERM).
+// On Windows Getuid/Getgid are -1 (invalid); tests that chown must skip.
+func testOwnerUID() string {
 	if uid := os.Getuid(); uid >= 0 {
 		return strconv.Itoa(uid)
+	}
+	return "243"
+}
+
+func testOwnerGID() string {
+	if gid := os.Getgid(); gid >= 0 {
+		return strconv.Itoa(gid)
 	}
 	return "243"
 }

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -90,6 +90,65 @@ func TestParseEndpoint(t *testing.T) {
 	}
 }
 
+func TestParseOwnerID(t *testing.T) {
+	tests := []struct {
+		desc        string
+		field       string
+		value       string
+		expectedID  int
+		expectedErr string
+	}{
+		{
+			desc:       "empty value is unset",
+			field:      paramUID,
+			value:      "",
+			expectedID: unsetOwner,
+		},
+		{
+			desc:       "valid uid",
+			field:      paramUID,
+			value:      "243",
+			expectedID: 243,
+		},
+		{
+			desc:       "zero is valid",
+			field:      paramGID,
+			value:      "0",
+			expectedID: 0,
+		},
+		{
+			desc:        "non-numeric",
+			field:       paramUID,
+			value:       "abc",
+			expectedErr: "invalid uid abc",
+		},
+		{
+			desc:        "negative",
+			field:       paramGID,
+			value:       "-1",
+			expectedErr: "invalid gid -1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			id, err := parseOwnerID(test.field, test.value)
+			if test.expectedErr != "" {
+				if err == nil || err.Error() != test.expectedErr {
+					t.Errorf("expected error %q, got %v", test.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if id != test.expectedID {
+				t.Errorf("expected id %d, got %d", test.expectedID, id)
+			}
+		})
+	}
+}
+
 func TestGetLogLevel(t *testing.T) {
 	tests := []struct {
 		method string

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -149,6 +149,55 @@ func TestParseOwnerID(t *testing.T) {
 	}
 }
 
+func TestChownIfOwnerMismatchInjected(t *testing.T) {
+	origFileOwner, origChownPath := fileOwnerFn, chownPathFn
+	t.Cleanup(func() {
+		fileOwnerFn = origFileOwner
+		chownPathFn = origChownPath
+	})
+
+	t.Run("one-sided uid passes -1 gid through to chown", func(t *testing.T) {
+		var gotUID, gotGID int
+		called := false
+		fileOwnerFn = func(string) (int, int, error) { return 0, 0, nil }
+		chownPathFn = func(_ string, uid, gid int) error {
+			called = true
+			gotUID, gotGID = uid, gid
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", 243, unsetOwner); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected chownPath to be called")
+		}
+		if gotUID != 243 || gotGID != unsetOwner {
+			t.Errorf("got %d:%d, want 243:%d", gotUID, gotGID, unsetOwner)
+		}
+	})
+
+	t.Run("matching owner skips chown", func(t *testing.T) {
+		fileOwnerFn = func(string) (int, int, error) { return 243, 243, nil }
+		chownPathFn = func(string, int, int) error {
+			t.Fatal("chownPath should not be called when owner already matches")
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", 243, 243); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both unset is a no-op", func(t *testing.T) {
+		chownPathFn = func(string, int, int) error {
+			t.Fatal("chownPath should not be called when both IDs are unset")
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", unsetOwner, unsetOwner); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestIsDynamicallyProvisioned(t *testing.T) {
 	tests := []struct {
 		desc     string


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds optional `uid` and `gid` StorageClass parameters (and matching static PV `volumeAttributes`) so the driver can `chown` the newly created NFS subdirectory. Today only `mountPermissions` exists; directories stay owned by root and unknown keys such as `permissions/uid` are rejected.

This came from a multi-tenant Kubernetes Slack discussion and is tracked in #1251 (related stale request: #183).

Behavior:
- `chown` the **volume subdirectory** in `CreateVolume` after mkdir
- re-apply on `NodePublishVolume` so static PVs work
- do **not** pass `uid`/`gid` into the internal share-root mount (avoids chowning the NFS export root)
- omit either parameter to leave that ID unchanged
- NFS export must allow `chown` (`no_root_squash` or an allowed squash uid)

**Which issue(s) this PR fixes**:
Fixes #1251

**Special notes for your reviewer**:
PVC-level owner fields and annotation templating are out of scope (called out on the issue). `fsGroup` remains supported and can still run after this chown.

**Does this PR introduce a user-facing change?**:
```release-note
feat: add optional uid/gid StorageClass parameters to chown dynamically provisioned NFS directories
```


Manual steps to verify the fix

After creating a local Rootful kind cluster  - important if you use rootless it can not do NFS kernel mounts.

1. export KUBECONFIG=~/.kube/config

2. compiling the new changes Rebuild the plugin
podman run --rm -v "$PWD:/src:Z" -w /src docker.io/library/golang:1.26 \
  sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -o bin/amd64/nfsplugin ./cmd/nfsplugin'

3. # image (Dockerfile copies bin/amd64/nfsplugin → /nfsplugin)
podman build --build-arg ARCH=amd64 -t docker.io/library/nfsplugin:uidgid .

4. Load it into kind. With podman, archive load is the reliable path:
podman save docker.io/library/nfsplugin:uidgid | sudo kind load image-archive /dev/stdin --name nfs-csi

pullPolicy: Never later means kubelet will only use this image. It will not pull upstream canary.  

5. Kind-on-podman: mask host USB devices

Privileged CSI pods can crash-loop when runc tries to bind-mount host USB devices. Hide them on the kind node:

sudo podman exec nfs-csi-control-plane sh -c \
  'mkdir -p /run/empty-usb /dev/bus/usb; mountpoint -q /dev/bus/usb || mount --bind /run/empty-usb /dev/bus/usb'

  This is an environment workaround, not part of the CSI feature.
  
  6. Give the NFS server a filesystem it can export
  Kernel nfsd cannot export overlayfs. Kind’s / is overlay, and the example server uses hostPath /nfs-vol. Put tmpfs there:
  
  sudo podman exec nfs-csi-control-plane sh -c \
  'mkdir -p /nfs-vol; mountpoint -q /nfs-vol || mount -t tmpfs -o size=512m tmpfs /nfs-vol; chmod 777 /nfs-vol; df -T /nfs-vol'

expected result
Filesystem     Type  1K-blocks  Used Available Use% Mounted on
tmpfs          tmpfs    524288     0    524288   0% /nfs-vol


7. Install the CSI driver using Helm
This creates:

- CSIDriver nfs.csi.k8s.io (fsGroupPolicy: File)
- controller Deployment: sidecars (csi-provisioner, …) + your nfsplugin (handles CreateVolume / chown)
- node DaemonSet: registrar + your nfsplugin (handles NodePublishVolume / mount)

helm install csi-driver-nfs ./charts/latest/csi-driver-nfs \
  --namespace kube-system \
  --set image.nfs.repository=docker.io/library/nfsplugin \
  --set image.nfs.tag=uidgid \
  --set image.nfs.pullPolicy=Never \
  --wait --timeout 3m

kubectl -n kube-system get pods -l app.kubernetes.io/instance=csi-driver-nfs
kubectl -n kube-system get deploy/csi-nfs-controller ds/csi-nfs-node \
  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.template.spec.containers[?(@.name=="nfs")].image}{"\n"}{end}'
  
  expected result
  NAME                                 READY   STATUS    RESTARTS   AGE
csi-nfs-controller-5f46c55bc-fqncr   5/5     Running   0          3s
csi-nfs-node-jtgv8                   3/3     Running   0          3s
csi-nfs-controller docker.io/library/nfsplugin:uidgid
csi-nfs-node docker.io/library/nfsplugin:uidgid

8. Start an NFS backend (not CSI)
Start an NFS backend (not CSI)
CSI-NFS does not ship an NFS server. This pod is just the share. It bind-mounts the kind node’s /nfs-vol as /exports and exports it with no_root_squash (needed for chown).

kubectl apply -f deploy/example/nfs-provisioner/nfs-server.yaml
kubectl -n default rollout status deploy/nfs-server --timeout=120s
kubectl logs deploy/nfs-server --tail=20
Look for Startup successful and /exports exported. Export validation failed means step 3 was skipped.


8. StorageClass — this is the new feature
provisioner: nfs.csi.k8s.io sends these parameters into CreateVolume. uid / gid are the new keys. Sidecars also inject PVC/PV name.

kubectl apply -f - <<'EOF'
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: nfs-csi
provisioner: nfs.csi.k8s.io
parameters:
  server: nfs-server.default.svc.cluster.local
  share: /
  mountPermissions: "0770"
  uid: "243"
  gid: "243"
reclaimPolicy: Delete
volumeBindingMode: Immediate
mountOptions:
  - nfsvers=4.1
EOF

expected result:
kginon@kginon-thinkpadp1gen7:~/k8s-projects/csi-driver-nfs$ kubectl get sc
NAME                 PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
nfs-csi              nfs.csi.k8s.io          Delete          Immediate              false                  18s
standard (default)   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  4h31m

9. PVC — this triggers CreateVolume

kubectl apply -f - <<'EOF'
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc-nfs-uidgid
spec:
  accessModes: [ReadWriteMany]
  resources:
    requests:
      storage: 1Gi
  storageClassName: nfs-csi
EOF

kubectl get pvc pvc-nfs-uidgid -w

kubectl get pvc pvc-nfs-uidgid -w
persistentvolumeclaim/pvc-nfs-uidgid created
NAME             STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
pvc-nfs-uidgid   Pending   pvc-116c3cd2-99be-4ca7-ab90-b87cf30b120b   0                         nfs-csi        <unset>                 0s
pvc-nfs-uidgid   Bound     pvc-116c3cd2-99be-4ca7-ab90-b87cf30b120b   1Gi        RWX            nfs-csi        <unset>                 0s


What happens:

csi-provisioner calls CreateVolume on the controller nfs container.
Plugin mounts nfs-server:/ internally, mkdir’s a subdir named after the PV.
chmod 0770, then chown 243:243 on that subdir only (not the export root).
Unmounts; Kubernetes binds the PVC to a PV whose source is server:/<subdir>.
Watch it:

10. Pod — this triggers NodePublishVolume

kubectl apply -f - <<'EOF'
apiVersion: v1
kind: Pod
metadata:
  name: uidgid-check
spec:
  securityContext:
    runAsUser: 243
    runAsGroup: 243
    fsGroup: 243
  containers:
    - name: pause
      image: registry.k8s.io/e2e-test-images/busybox:1.36.1-1
      command: ["sleep", "3600"]
      volumeMounts:
        - name: data
          mountPath: /mnt/nfs
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: pvc-nfs-uidgid
EOF

kubectl wait --for=condition=Ready pod/uidgid-check --timeout=120s

Excepted result:
pod/uidgid-check created
pod/uidgid-check condition met

runAsUser/runAsGroup are so the process is 243 (otherwise you cannot write even if the dir is 243). fsGroup is kubelet’s extra pass (fsGroupPolicy: File); it can add the setgid s bit. The uid/gid on the directory should already be 243 from step 7.

11. Verify (plugin vs kubelet vs backing store)
# what the pods sees

kginon@kginon-thinkpadp1gen7:~/k8s-projects/csi-driver-nfs$ kubectl exec uidgid-check -- ls -ldn /mnt/nfs
kubectl exec uidgid-check -- sh -c 'touch /mnt/nfs/from-pod && ls -ln /mnt/nfs/from-pod'
drwxrws---    2 243      243             40 Aug 23 08:57 /mnt/nfs
-rw-r--r--    1 243      243              0 Aug 23 09:03 /mnt/nfs/from-pod


sudo podman exec nfs-csi-control-plane ls -ln /nfs-vol

sudo podman exec nfs-csi-control-plane sh -c 'ls -ldn /nfs-vol/pvc-*'
total 0
drwxrws---. 2 243 243 60 Aug 23 09:02 pvc-116c3cd2-99be-4ca7-ab90-b87cf30b120b
drwxrws---. 2 243 243 60 Aug 23 09:02 /nfs-vol/pvc-116c3cd2-99be-4ca7-ab90-b87cf30b120b

Expect:

/mnt/nfs → drwxrws--- 243:243
from-pod created as 243:243
kind node /nfs-vol/<pv-name> same ownership
/nfs-vol itself still root:root — only the PVC subdir was chown’d

