### PR TITLE
test: add uid/gid StorageClass parameter test

### DIFF
--- a/test/e2e/dynamic_provisioning_test.go
+++ b/test/e2e/dynamic_provisioning_test.go
@@ -98,6 +98,36 @@ var _ = ginkgo.Describe("Dynamic Provisioning", func() {
 		test.Run(ctx, cs, ns)
 	})
 
+	ginkgo.It("should create a volume on demand with uid/gid StorageClass parameters", func(ctx ginkgo.SpecContext) {
+		if isWindowsCluster {
+			ginkgo.Skip("uid/gid chown is not supported on Windows")
+		}
+		// StorageClass sets uid=1001 gid=1002; verify the CreateVolume
+		// chown landed on the subdirectory owner as observed from a pod.
+		// The pod runs as root and does not set fsGroup, so kubelet will
+		// not overwrite the GID after NodePublishVolume.
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: "owner=$(stat -c '%u:%g' /mnt/test-1) && echo \"owner=$owner\" && [ \"$owner\" = \"1001:1002\" ]",
+				Volumes: []testsuites.VolumeDetails{
+					{
+						ClaimSize: "10Gi",
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver:              testDriver,
+			Pods:                   pods,
+			StorageClassParameters: storageClassParametersWithUIDGID,
+		}
+		test.Run(ctx, cs, ns)
+	})
+
 	ginkgo.It("should create multiple PV objects, bind to PVCs and attach all to different pods on the same node", func(ctx ginkgo.SpecContext) {
 		pods := []testsuites.PodDetails{
 			{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,6 +59,15 @@ var (
 		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
 		"mountPermissions": "0",
 	}
+	storageClassParametersWithUIDGID = map[string]string{
+		"server": nfsServerAddress,
+		"share":  nfsShare,
+		"csi.storage.k8s.io/provisioner-secret-name":      "mount-options",
+		"csi.storage.k8s.io/provisioner-secret-namespace": "default",
+		"mountPermissions": "0770",
+		"uid":              "1001",
+		"gid":              "1002",
+	}
 	subDirStorageClassParameters = map[string]string{
 		"server": nfsServerAddress,
 		"share":  nfsShare,


### PR DESCRIPTION
**What this PR does / why we need it**

Adds an e2e test covering the `uid` / `gid` StorageClass parameters introduced in #1252. The test provisions a PVC with `uid=1001` and `gid=1002`, mounts it into a pod, and asserts that `stat -c '%u:%g'` on the volume mount returns `1001:1002` — proving the `CreateVolume` chown reached the subdirectory and the ownership is visible to the workload.

The test is skipped on Windows clusters, matching the driver's platform gating (`chown` is Linux-only in the driver).

**Which issue(s) this PR fixes**

Follow-up test coverage for #1252.

**Requirements**

- [x] Skips on Windows.
- [x] Pod runs as root and does not set `fsGroup`, so kubelet does not overwrite the GID after `NodePublishVolume` — the assertion tests the driver behavior in isolation.
- [x] Uses the existing `DynamicallyProvisionedCmdVolumeTest` harness, matching the surrounding tests.