### PR TITLE
[release-4.13] feat: add uid/gid StorageClass parameters for volume directory ownership

### DIFF
--- a/deploy/example/pv-nfs-csi.yaml
+++ b/deploy/example/pv-nfs-csi.yaml
@@ -22,3 +22,5 @@ spec:
     volumeAttributes:
       server: nfs-server.default.svc.cluster.local
       share: /
+      # uid: "243"
+      # gid: "243"

--- a/deploy/example/storageclass-nfs.yaml
+++ b/deploy/example/storageclass-nfs.yaml
@@ -7,6 +7,9 @@ provisioner: nfs.csi.k8s.io
 parameters:
   server: nfs-server.default.svc.cluster.local
   share: /
+  # mountPermissions: "0770"
+  # uid: "243"
+  # gid: "243"
   # csi.storage.k8s.io/provisioner-secret is only needed for providing mountOptions in DeleteVolume
   # csi.storage.k8s.io/provisioner-secret-name: "mount-options"
   # csi.storage.k8s.io/provisioner-secret-namespace: "default"

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -9,7 +9,9 @@ Name | Meaning | Example Value | Mandatory | Default value
 server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 share | NFS share path | `/` | Yes |
 subDir | sub directory under nfs share |  | No | if sub directory does not exist, this driver would create a new one
-mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount |  | No |
+mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+uid | numeric user ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+gid | numeric group ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 onDelete | when volume is deleted, keep the directory if it's `retain` | `delete`(default), `retain`, `archive`  | No | `delete`
 
  - VolumeID(`volumeHandle`) is the identifier of the volume handled by the driver, format of VolumeID:
@@ -26,7 +28,9 @@ Name | Meaning | Example Value | Mandatory | Default value
 volumeHandle | Specify a value the driver can use to uniquely identify the share in the cluster. | A recommended way to produce a unique value is to combine the nfs-server address, sub directory name and share name: `{nfs-server-address}#{share-name}#{sub-dir-name}`. | Yes |
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
-volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount |  | No |
+volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+volumeAttributes.uid | numeric user ID to `chown` the mount directory to in writable `NodePublishVolume` (static PVs have no `CreateVolume`; Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
+volumeAttributes.gid | numeric group ID to `chown` the mount directory to in writable `NodePublishVolume` (Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 
 ### `VolumeSnapshotClass`
 
@@ -47,6 +51,67 @@ Name | Meaning | Available Value | Mandatory | Default value
 > **Note:** When `--enable-snapshot-compression=false`, snapshots are stored without gzip compression (using `.tar` format instead of `.tar.gz`). This can significantly speed up snapshot creation and restoration for volumes containing already-compressed data. The driver automatically detects the archive format when restoring from a snapshot, ensuring backward compatibility with existing compressed snapshots.
 
 ### Tips
+#### When to set `mountPermissions`
+> By default (`mountPermissions: 0`) the driver does **not** run `chmod` on the mount root after mounting. For **dynamically provisioned** volumes the controller creates the sub-directory with `os.MkdirAll(..., 0777)`, which is then masked by the controller pod's umask (typically `022`), so the resulting mode is usually `0755`. For **statically provisioned** volumes no `MkdirAll` runs and the mount root keeps whatever mode the NFS server already has on the share. Either way, the driver leaves the mode to the underlying filesystem rather than forcing a permissive bit pattern.
+
+If your pods run as **non-root** and get `Permission denied` when writing to the volume, you have three options, listed from most to least preferred:
+
+1. **Use `securityContext.fsGroup` on the pod.** The kubelet's fsGroup logic changes ownership of the mounted volume so that the pod's group can write to it. No driver-side `chmod` needed. This is the standard Kubernetes pattern.
+   ```yaml
+   spec:
+     securityContext:
+       fsGroup: 2000
+   ```
+   > Prerequisites: the `CSIDriver` object must advertise `fsGroupPolicy: File` (the driver ships this by default — see [`deploy/example/fsgroup/README.md`](../deploy/example/fsgroup/README.md)), and the NFS export must allow the kubelet-issued `chown`/`chgrp` on the mount root (i.e. `no_root_squash`, or a `squash_uid` that owns the share). Root-squashed exports may reject the ownership change and surface as a mount failure instead of a write failure.
+2. **Relax the umask on the CSI controller process** so newly created sub-directories are group-writable. Lower the umask of the CSI controller container (e.g. wrap the entrypoint with `umask 002` in the container `command`) so subsequent `MkdirAll(0777)` calls stay at `0775`/`0777`. This is a per-directory fix and only affects sub-directories created after the change.
+3. **Set `mountPermissions` as a last resort.** The driver will `chmod` the mount root to the given mode after each mount. Where to set it depends on how the driver is deployed / how the volume is provisioned:
+   - **Cluster-wide default** — set it once in the Helm chart. `driver.mountPermissions` in `values.yaml` is threaded into the `--mount-permissions` flag on both the controller and node DaemonSet (`charts/latest/csi-driver-nfs/templates/csi-nfs-{controller,node}.yaml`), so every volume served by that driver install picks it up:
+     ```yaml
+     driver:
+       mountPermissions: "0775"
+     ```
+   - **Dynamic provisioning** — override per-StorageClass under `parameters`:
+     ```yaml
+     parameters:
+       mountPermissions: "0777"
+     ```
+   - **Static provisioning** — set it under `spec.csi.volumeAttributes` on the PersistentVolume:
+     ```yaml
+     spec:
+       csi:
+         volumeAttributes:
+           mountPermissions: "0777"
+     ```
+   > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
+
+#### When to set `uid`/`gid`
+> Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir (and after clone/snapshot copy, so `cp -a` / tar cannot restore the source owner). `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes. `uid`/`gid` are Linux-only: `CreateVolume` and writable static publishes return an error on Windows; read-only static publishes skip `chown` and succeed.
+
+For **static PVs** there is no `CreateVolume`, so the same keys on `volumeAttributes` are applied in `NodePublishVolume` after mount (including retries when the target is already mounted). Read-only publishes skip `chown`.
+
+This driver ships `fsGroupPolicy: File`. After `NodePublishVolume` returns, kubelet applies `pod.spec.securityContext.fsGroup` when it is set:
+
+- kubelet runs `chown(-1, fsGroup)` recursively: **UID is left unchanged, GID is replaced**, and the setgid bit is set
+- a pod `fsGroup` therefore **overwrites StorageClass/PV `gid`**. If you need the StorageClass `gid` to remain the group on disk, omit `fsGroup`, or set it to the same GID
+- StorageClass `uid` is not overwritten by `fsGroup`
+
+Use `uid`/`gid` when the volume directory should be owned at provision time (or at first mount for static PVs), including for pods that do not set `fsGroup`. Use `fsGroup` when kubelet should grant the pod's group write access at mount time. Do not combine them with **different** GIDs.
+
+NFS has no portable `uid=` / `gid=` mount options (unlike SMB/CIFS). This is an explicit `chown`, so the NFS export must allow it (`no_root_squash`, or a squash uid that is allowed to own the path). Root-squashed exports typically leave the directory owned by `nobody` and provisioning or mount will fail if `uid`/`gid` cannot be applied.
+
+```yaml
+parameters:
+  server: nfs-server.default.svc.cluster.local
+  share: /
+  mountPermissions: "0770"
+  uid: "243"
+  gid: "243"
+```
+
+Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers.
+
+These are StorageClass (or static PV `volumeAttributes`) parameters. The PVC API has no owner fields; CSI only forwards StorageClass parameters. One StorageClass per tenant uid is the supported pattern today.
+
 #### `subDir` parameter supports following pv/pvc metadata conversion
 > if `subDir` value contains following strings, it would be converted into corresponding pv/pvc name or namespace
  - `${pvc.metadata.name}`

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -9,7 +9,7 @@ Name | Meaning | Example Value | Mandatory | Default value
 server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 share | NFS share path | `/` | Yes |
 subDir | sub directory under nfs share |  | No | if sub directory does not exist, this driver would create a new one
-mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount |  | No |
 uid | numeric user ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave ownership unchanged (typically root, subject to NFS squash). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
 gid | numeric group ID to `chown` the newly created subdirectory to in `CreateVolume` (Linux only). Omit to leave group unchanged. See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 onDelete | when volume is deleted, keep the directory if it's `retain` | `delete`(default), `retain`, `archive`  | No | `delete`
@@ -28,7 +28,7 @@ Name | Meaning | Example Value | Mandatory | Default value
 volumeHandle | Specify a value the driver can use to uniquely identify the share in the cluster. | A recommended way to produce a unique value is to combine the nfs-server address, sub directory name and share name: `{nfs-server-address}#{share-name}#{sub-dir-name}`. | Yes |
 volumeAttributes.server | NFS Server address | domain name `nfs-server.default.svc.cluster.local` <br>or IP address `127.0.0.1` | Yes |
 volumeAttributes.share | NFS share path | `/` |  Yes  |
-volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount. See [When to set `mountPermissions`](#when-to-set-mountpermissions) below. |  | No |
+volumeAttributes.mountPermissions | mounted folder permissions. The default is `0`, if set as non-zero, driver will perform `chmod` after mount |  | No |
 volumeAttributes.uid | numeric user ID to `chown` the mount directory to in writable `NodePublishVolume` (static PVs have no `CreateVolume`; Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. | `"243"` | No |
 volumeAttributes.gid | numeric group ID to `chown` the mount directory to in writable `NodePublishVolume` (Linux only; read-only publishes skip `chown`). See [When to set `uid`/`gid`](#when-to-set-uidgid) below. Kubelet `fsGroup` overwrites this GID at mount if the pod sets it. | `"243"` | No |
 
@@ -51,39 +51,6 @@ Name | Meaning | Available Value | Mandatory | Default value
 > **Note:** When `--enable-snapshot-compression=false`, snapshots are stored without gzip compression (using `.tar` format instead of `.tar.gz`). This can significantly speed up snapshot creation and restoration for volumes containing already-compressed data. The driver automatically detects the archive format when restoring from a snapshot, ensuring backward compatibility with existing compressed snapshots.
 
 ### Tips
-#### When to set `mountPermissions`
-> By default (`mountPermissions: 0`) the driver does **not** run `chmod` on the mount root after mounting. For **dynamically provisioned** volumes the controller creates the sub-directory with `os.MkdirAll(..., 0777)`, which is then masked by the controller pod's umask (typically `022`), so the resulting mode is usually `0755`. For **statically provisioned** volumes no `MkdirAll` runs and the mount root keeps whatever mode the NFS server already has on the share. Either way, the driver leaves the mode to the underlying filesystem rather than forcing a permissive bit pattern.
-
-If your pods run as **non-root** and get `Permission denied` when writing to the volume, you have three options, listed from most to least preferred:
-
-1. **Use `securityContext.fsGroup` on the pod.** The kubelet's fsGroup logic changes ownership of the mounted volume so that the pod's group can write to it. No driver-side `chmod` needed. This is the standard Kubernetes pattern.
-   ```yaml
-   spec:
-     securityContext:
-       fsGroup: 2000
-   ```
-   > Prerequisites: the `CSIDriver` object must advertise `fsGroupPolicy: File` (the driver ships this by default — see [`deploy/example/fsgroup/README.md`](../deploy/example/fsgroup/README.md)), and the NFS export must allow the kubelet-issued `chown`/`chgrp` on the mount root (i.e. `no_root_squash`, or a `squash_uid` that owns the share). Root-squashed exports may reject the ownership change and surface as a mount failure instead of a write failure.
-2. **Relax the umask on the CSI controller process** so newly created sub-directories are group-writable. Lower the umask of the CSI controller container (e.g. wrap the entrypoint with `umask 002` in the container `command`) so subsequent `MkdirAll(0777)` calls stay at `0775`/`0777`. This is a per-directory fix and only affects sub-directories created after the change.
-3. **Set `mountPermissions` as a last resort.** The driver will `chmod` the mount root to the given mode after each mount. Where to set it depends on how the driver is deployed / how the volume is provisioned:
-   - **Cluster-wide default** — set it once in the Helm chart. `driver.mountPermissions` in `values.yaml` is threaded into the `--mount-permissions` flag on both the controller and node DaemonSet (`charts/latest/csi-driver-nfs/templates/csi-nfs-{controller,node}.yaml`), so every volume served by that driver install picks it up:
-     ```yaml
-     driver:
-       mountPermissions: "0775"
-     ```
-   - **Dynamic provisioning** — override per-StorageClass under `parameters`:
-     ```yaml
-     parameters:
-       mountPermissions: "0777"
-     ```
-   - **Static provisioning** — set it under `spec.csi.volumeAttributes` on the PersistentVolume:
-     ```yaml
-     spec:
-       csi:
-         volumeAttributes:
-           mountPermissions: "0777"
-     ```
-   > ⚠️ `mountPermissions: "0777"` makes the share world-writable and does not solve cross-GID isolation: any pod on the node can write. Do not use this on NFS servers shared across trust boundaries or multi-tenant clusters. Prefer option 1 (with a matching GID) or option 2 first.
-
 #### When to set `uid`/`gid`
 > Dynamically provisioned subdirectories are created by the controller as root. `mountPermissions` can change the mode, but not the owner. Optional `uid` / `gid` StorageClass parameters run `chown` on **that subdirectory only** (not the NFS share root) in `CreateVolume` after mkdir (and after clone/snapshot copy, so `cp -a` / tar cannot restore the source owner). `NodePublishVolume` does **not** repeat that `chown` for dynamic volumes. `uid`/`gid` are Linux-only: `CreateVolume` and writable static publishes return an error on Windows; read-only static publishes skip `chown` and succeed.
 
@@ -108,7 +75,7 @@ parameters:
   gid: "243"
 ```
 
-Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers.
+Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers in the range `0`–`2147483647` (the driver parses uid/gid as signed 32-bit ints; values above `math.MaxInt32` are rejected).
 
 These are StorageClass (or static PV `volumeAttributes`) parameters. The PVC API has no owner fields; CSI only forwards StorageClass parameters. One StorageClass per tenant uid is the supported pattern today.
 

--- a/pkg/nfs/chmod_unix.go
+++ b/pkg/nfs/chmod_unix.go
@@ -19,11 +19,33 @@ limitations under the License.
 
 package nfs
 
-import "syscall"
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
 
 // chmod uses syscall.Chmod to correctly handle setuid/setgid/sticky bits
 // (e.g. 02770), since os.Chmod maps os.FileMode bits differently from raw
 // Unix mode bits.
 func chmod(path string, mode uint32) error {
 	return syscall.Chmod(path, mode)
+}
+
+func fileOwner(path string) (int, int, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return unsetOwner, unsetOwner, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return unsetOwner, unsetOwner, fmt.Errorf("failed to get uid/gid for %s", path)
+	}
+	return int(stat.Uid), int(stat.Gid), nil
+}
+
+func chownPath(path string, uid, gid int) error {
+	// Lchown matches fileOwner's Lstat: do not follow a symlink to a
+	// different inode than the path we inspected.
+	return os.Lchown(path, uid, gid)
 }

--- a/pkg/nfs/chmod_unix_test.go
+++ b/pkg/nfs/chmod_unix_test.go
@@ -84,3 +84,33 @@ func TestChmodIfPermissionMismatchSpecialBits(t *testing.T) {
 		})
 	}
 }
+
+func TestChownIfOwnerMismatch(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := dir + "/testdir"
+	if err := os.Mkdir(targetPath, 0777); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+
+	uid := os.Getuid()
+	gid := os.Getgid()
+
+	// Same-owner call only exercises the skip path. Mutation and one-sided
+	// unsetOwner behavior are covered by TestChownIfOwnerMismatchInjected in utils_test.go
+	// (injected fileOwner/chownPath, no root required).
+	if err := chownIfOwnerMismatch(targetPath, uid, gid); err != nil {
+		t.Fatalf("chownIfOwnerMismatch to current owner failed: %v", err)
+	}
+
+	if err := chownIfOwnerMismatch(targetPath, unsetOwner, unsetOwner); err != nil {
+		t.Fatalf("chownIfOwnerMismatch with both unset failed: %v", err)
+	}
+
+	gotUID, gotGID, err := fileOwner(targetPath)
+	if err != nil {
+		t.Fatalf("fileOwner failed: %v", err)
+	}
+	if gotUID != uid || gotGID != gid {
+		t.Errorf("expected owner %d:%d, got %d:%d", uid, gid, gotUID, gotGID)
+	}
+}

--- a/pkg/nfs/chmod_windows.go
+++ b/pkg/nfs/chmod_windows.go
@@ -19,10 +19,27 @@ limitations under the License.
 
 package nfs
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 // chmod falls back to os.Chmod on Windows, which does not support
 // setuid/setgid/sticky bits but avoids a build failure.
 func chmod(path string, mode uint32) error {
 	return os.Chmod(path, os.FileMode(mode))
+}
+
+func fileOwner(path string) (int, int, error) {
+	if _, err := os.Lstat(path); err != nil {
+		return unsetOwner, unsetOwner, err
+	}
+	return unsetOwner, unsetOwner, nil
+}
+
+func chownPath(_ string, uid, gid int) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	return fmt.Errorf("uid/gid is not supported on Windows")
 }

--- a/pkg/nfs/controllerserver.go
+++ b/pkg/nfs/controllerserver.go
@@ -127,6 +127,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	mountPermissions := cs.Driver.mountPermissions
+	uid, gid := unsetOwner, unsetOwner
 	reqCapacity := req.GetCapacityRange().GetRequiredBytes()
 	parameters := req.GetParameters()
 	if parameters == nil {
@@ -148,6 +149,20 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 				var err error
 				if mountPermissions, err = strconv.ParseUint(v, 8, 32); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid mountPermissions %s in storage class", v)
+				}
+			}
+		case paramUID:
+			{
+				var err error
+				if uid, err = parseOwnerID(paramUID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
+				}
+			}
+		case paramGID:
+			{
+				var err error
+				if gid, err = parseOwnerID(paramGID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
 				}
 			}
 		default:
@@ -199,6 +214,12 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if err := cs.copyVolume(ctx, req, nfsVol); err != nil {
 			return nil, err
 		}
+	}
+
+	// Apply after copyVolume: cp -a / tar restore can overwrite the
+	// destination directory's owner with the source metadata.
+	if err := chownIfOwnerMismatch(internalVolumePath, uid, gid); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to chown subdirectory: %v", err)
 	}
 
 	setKeyValueInMap(parameters, paramSubDir, nfsVol.subDir)
@@ -524,9 +545,11 @@ func (cs *ControllerServer) internalMount(ctx context.Context, vol *nfsVolume, v
 	for k, v := range volumeContext {
 		// don't set subDir, server, or share fields: only nfs-server:/share
 		// should be mounted via the volume's own values across all internal
-		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.)
+		// mount callers (CreateVolume, DeleteVolume, CreateSnapshot, etc.).
+		// uid/gid must also be omitted: NodePublishVolume still chowns
+		// static PVs and would otherwise chown the NFS share root.
 		switch strings.ToLower(k) {
-		case paramSubDir, paramServer, paramShare:
+		case paramSubDir, paramServer, paramShare, paramUID, paramGID:
 			continue
 		default:
 			volContext[k] = v

--- a/pkg/nfs/controllerserver_test.go
+++ b/pkg/nfs/controllerserver_test.go
@@ -86,10 +86,12 @@ func TestMain(m *testing.M) {
 
 func TestCreateVolume(t *testing.T) {
 	cases := []struct {
-		name      string
-		req       *csi.CreateVolumeRequest
-		resp      *csi.CreateVolumeResponse
-		expectErr bool
+		name          string
+		req           *csi.CreateVolumeRequest
+		resp          *csi.CreateVolumeResponse
+		expectErr     bool
+		skipOnWindows bool
+		windowsOnly   bool
 	}{
 		{
 			name: "valid defaults",
@@ -216,10 +218,119 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "valid uid and gid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    testOwnerUID(),
+					paramGID:    testOwnerGID(),
+				},
+			},
+			resp: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					VolumeId: newTestVolumeID,
+					VolumeContext: map[string]string{
+						paramServer: testServer,
+						paramShare:  testBaseDir,
+						paramSubDir: testCSIVolume,
+						paramUID:    testOwnerUID(),
+						paramGID:    testOwnerGID(),
+					},
+				},
+			},
+			skipOnWindows: true,
+		},
+		{
+			name: "[Error] uid/gid not supported on Windows",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    "243",
+					paramGID:    "243",
+				},
+			},
+			expectErr:   true,
+			windowsOnly: true,
+		},
+		{
+			name: "[Error] invalid uid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramUID:    "abc",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "[Error] invalid gid",
+			req: &csi.CreateVolumeRequest{
+				Name: testCSIVolume,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+				Parameters: map[string]string{
+					paramServer: testServer,
+					paramShare:  testBaseDir,
+					paramGID:    "-1",
+				},
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" && test.skipOnWindows {
+				t.Skip("uid/gid chown is not supported on Windows")
+			}
+			if runtime.GOOS != "windows" && test.windowsOnly {
+				t.Skip("Windows-only")
+			}
 			// Setup
 			cs := initTestController(t)
 			// Run

--- a/pkg/nfs/nfs.go
+++ b/pkg/nfs/nfs.go
@@ -78,12 +78,17 @@ const (
 	paramOnDelete         = "ondelete"
 	mountOptionsField     = "mountoptions"
 	mountPermissionsField = "mountpermissions"
+	paramUID              = "uid"
+	paramGID              = "gid"
 	pvcNameKey            = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey       = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey             = "csi.storage.k8s.io/pv/name"
-	pvcNameMetadata       = "${pvc.metadata.name}"
-	pvcNamespaceMetadata  = "${pvc.metadata.namespace}"
-	pvNameMetadata        = "${pv.metadata.name}"
+	// csiProvisionerIdentityKey is added to dynamically provisioned PVs by
+	// external-provisioner. Presence means CreateVolume already ran.
+	csiProvisionerIdentityKey = "storage.kubernetes.io/csiProvisionerIdentity"
+	pvcNameMetadata           = "${pvc.metadata.name}"
+	pvcNamespaceMetadata      = "${pvc.metadata.namespace}"
+	pvNameMetadata            = "${pv.metadata.name}"
 )
 
 func NewDriver(options *DriverOptions) *Driver {

--- a/pkg/nfs/nodeserver.go
+++ b/pkg/nfs/nodeserver.go
@@ -76,6 +76,7 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	subDirReplaceMap := map[string]string{}
 
 	mountPermissions := ns.Driver.mountPermissions
+	uid, gid := unsetOwner, unsetOwner
 	for k, v := range req.GetVolumeContext() {
 		switch strings.ToLower(k) {
 		case paramServer:
@@ -99,6 +100,20 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 				var err error
 				if mountPermissions, err = strconv.ParseUint(v, 8, 32); err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid mountPermissions %s", v)
+				}
+			}
+		case paramUID:
+			{
+				var err error
+				if uid, err = parseOwnerID(paramUID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
+				}
+			}
+		case paramGID:
+			{
+				var err error
+				if gid, err = parseOwnerID(paramGID, v); err != nil {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
 				}
 			}
 		}
@@ -146,6 +161,9 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 			}
 			// fall through to remount
 		} else {
+			if err := ns.applyUIDGID(targetPath, uid, gid, req.GetReadonly(), req.GetVolumeContext()); err != nil {
+				return nil, status.Error(codes.Internal, err.Error())
+			}
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 	}
@@ -174,8 +192,30 @@ func (ns *NodeServer) NodePublishVolume(_ context.Context, req *csi.NodePublishV
 	} else {
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mountPermissions is set as 0", targetPath)
 	}
+
+	if err := ns.applyUIDGID(targetPath, uid, gid, req.GetReadonly(), req.GetVolumeContext()); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	klog.V(2).Infof("volume(%s) mount %s on %s succeeded", volumeID, source, targetPath)
 	return &csi.NodePublishVolumeResponse{}, nil
+}
+
+// applyUIDGID chowns static PVs after mount. Dynamic volumes are already
+// owned in CreateVolume. Skip read-only publishes: the mount is ro so chown
+// would fail.
+func (ns *NodeServer) applyUIDGID(targetPath string, uid, gid int, readonly bool, volumeContext map[string]string) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	if readonly {
+		klog.V(2).Infof("skip chown on targetPath(%s): volume is read-only", targetPath)
+		return nil
+	}
+	if isDynamicallyProvisioned(volumeContext) {
+		klog.V(2).Infof("skip chown on targetPath(%s): uid/gid already applied in CreateVolume", targetPath)
+		return nil
+	}
+	return chownIfOwnerMismatch(targetPath, uid, gid)
 }
 
 // NodeUnpublishVolume unmount the volume

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -236,9 +236,9 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeContext:    paramsWithOwnerDynamic,
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:         "vol_1",
-				TargetPath:       targetTest,
-				Readonly:         true},
-			expectedErr: nil,
+				TargetPath:       targetTest},
+			skipOnWindows: true,
+			expectedErr:   nil,
 		},
 		{
 			desc: "[Success] Static PV with pv name metadata still applies uid and gid",

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -65,6 +66,36 @@ func TestNodePublishVolume(t *testing.T) {
 		"server":              "server",
 		"share":               "share",
 		mountPermissionsField: "07ab",
+	}
+
+	paramsWithOwner := map[string]string{
+		"server": "server",
+		"share":  "share",
+		paramUID: testOwnerUID(),
+		paramGID: testOwnerGID(),
+	}
+
+	paramsWithOwnerDynamic := map[string]string{
+		"server":                  "server",
+		"share":                   "share",
+		paramUID:                  testOwnerUID(),
+		paramGID:                  testOwnerGID(),
+		pvNameKey:                 "pvname",
+		csiProvisionerIdentityKey: "nfs.csi.k8s.io",
+	}
+
+	paramsWithOwnerStaticPVName := map[string]string{
+		"server":  "server",
+		"share":   "share",
+		paramUID:  testOwnerUID(),
+		paramGID:  testOwnerGID(),
+		pvNameKey: "pvname",
+	}
+
+	invalidUIDParams := map[string]string{
+		"server": "server",
+		"share":  "share",
+		paramUID: "abc",
 	}
 
 	volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
@@ -180,6 +211,56 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedErr: status.Error(codes.InvalidArgument, "invalid mountPermissions 07ab"),
 		},
 		{
+			desc: "[Success] Valid request with uid and gid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwner,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: nil,
+		},
+		{
+			desc: "[Success] Already mounted static PV with uid and gid still applies owner",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwner,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       alreadyMountedTarget},
+			skipOnWindows: true,
+			expectedErr:   nil,
+		},
+		{
+			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwnerDynamic,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: nil,
+		},
+		{
+			desc: "[Success] Static PV with pv name metadata still applies uid and gid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    paramsWithOwnerStaticPVName,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       alreadyMountedTarget},
+			skipOnWindows: true,
+			expectedErr:   nil,
+		},
+		{
+			desc: "[Error] invalid uid",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeContext:    invalidUIDParams,
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1",
+				TargetPath:       targetTest,
+				Readonly:         true},
+			expectedErr: status.Error(codes.InvalidArgument, "invalid uid abc"),
+		},
+		{
 			desc: "[Success] Stale mount detected and remounted",
 			setup: func() {
 				lstatFunc = func(name string) (os.FileInfo, error) {
@@ -204,6 +285,9 @@ func TestNodePublishVolume(t *testing.T) {
 	_ = makeDir(targetTest)
 
 	for _, tc := range tests {
+		if runtime.GOOS == "windows" && tc.skipOnWindows {
+			continue
+		}
 		if tc.setup != nil {
 			tc.setup()
 		}

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -232,6 +232,17 @@ func TestNodePublishVolume(t *testing.T) {
 		},
 		{
 			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
+			setup: func() {
+				// Force any owner-lookup or chown attempt to fail. This test
+				// only passes if applyUIDGID returns via the dynamic-volume
+				// short-circuit before reaching chownIfOwnerMismatch.
+				fileOwnerFn = func(string) (int, int, error) {
+					return 0, 0, fmt.Errorf("fileOwnerFn should not be called for dynamic volumes")
+				}
+				chownPathFn = func(string, int, int) error {
+					return fmt.Errorf("chownPathFn should not be called for dynamic volumes")
+				}
+			},
 			req: &csi.NodePublishVolumeRequest{
 				VolumeContext:    paramsWithOwnerDynamic,
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -239,6 +250,10 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetTest},
 			skipOnWindows: true,
 			expectedErr:   nil,
+			cleanup: func() {
+				fileOwnerFn = fileOwner
+				chownPathFn = chownPath
+			},
 		},
 		{
 			desc: "[Success] Static PV with pv name metadata still applies uid and gid",

--- a/pkg/nfs/utils.go
+++ b/pkg/nfs/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,9 +42,18 @@ const (
 	retain                          = "retain"
 	archive                         = "archive"
 	volumeOperationAlreadyExistsFmt = "An operation with the given Volume ID %s already exists"
+	// unsetOwner is passed to os.Lchown to leave uid or gid unchanged.
+	unsetOwner = -1
 )
 
 var supportedOnDeleteValues = []string{"", delete, retain, archive}
+
+// fileOwnerFn and chownPathFn are overridden in tests to cover one-sided
+// uid/gid updates without requiring root.
+var (
+	fileOwnerFn = fileOwner
+	chownPathFn = chownPath
+)
 
 func validateOnDeleteValue(onDelete string) error {
 	for _, v := range supportedOnDeleteValues {
@@ -209,6 +219,60 @@ func chmodIfPermissionMismatch(targetPath string, mode uint32) error {
 		klog.V(2).Infof("skip chmod on targetPath(%s) since mode is already 0%o", targetPath, mode)
 	}
 	return nil
+}
+
+// isDynamicallyProvisioned reports whether volumeContext belongs to a PV
+// created by the CSI provisioner (CreateVolume already applied uid/gid).
+// Only csiProvisionerIdentityKey is used: pvNameKey is also a documented
+// static PV attribute for ${pv.metadata.name} subDir substitution.
+func isDynamicallyProvisioned(volumeContext map[string]string) bool {
+	for k := range volumeContext {
+		if strings.EqualFold(k, csiProvisionerIdentityKey) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseOwnerID parses an optional numeric uid/gid StorageClass parameter.
+// An empty value means "leave this ID unchanged".
+func parseOwnerID(field, value string) (int, error) {
+	if value == "" {
+		return unsetOwner, nil
+	}
+	id, err := strconv.ParseInt(value, 10, 32)
+	if err != nil || id < 0 {
+		return unsetOwner, fmt.Errorf("invalid %s %s", field, value)
+	}
+	return int(id), nil
+}
+
+// chownIfOwnerMismatch only performs chown when uid/gid are set and the
+// current owner does not already match. uid or gid may be unsetOwner (-1) to
+// leave that ID unchanged, matching os.Lchown.
+func chownIfOwnerMismatch(targetPath string, uid, gid int) error {
+	if uid == unsetOwner && gid == unsetOwner {
+		return nil
+	}
+	currentUID, currentGID, err := fileOwnerFn(targetPath)
+	if err != nil {
+		return err
+	}
+	wantUID, wantGID := uid, gid
+	if uid == unsetOwner {
+		wantUID = currentUID
+	}
+	if gid == unsetOwner {
+		wantGID = currentGID
+	}
+	if currentUID == wantUID && currentGID == wantGID {
+		klog.V(2).Infof("skip chown on targetPath(%s) since owner is already %d:%d", targetPath, currentUID, currentGID)
+		return nil
+	}
+	// Pass the original uid/gid (possibly unsetOwner / -1) so os.Lchown
+	// leaves an omitted ID unchanged atomically.
+	klog.V(2).Infof("chown targetPath(%s, current %d:%d) to %d:%d", targetPath, currentUID, currentGID, uid, gid)
+	return chownPathFn(targetPath, uid, gid)
 }
 
 // getServerFromSource if server is IPv6, return [IPv6]

--- a/pkg/nfs/utils_test.go
+++ b/pkg/nfs/utils_test.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,24 @@ var (
 	invalidEndpoint = "invalid-endpoint"
 	emptyAddr       = "tcp://"
 )
+
+// testOwnerUID/testOwnerGID are uid/gid strings parseOwnerID accepts.
+// On Unix they match the process so chownIfOwnerMismatch is a no-op without
+// root. Using uid for both would try to change the group (often EPERM).
+// On Windows Getuid/Getgid are -1 (invalid); tests that chown must skip.
+func testOwnerUID() string {
+	if uid := os.Getuid(); uid >= 0 {
+		return strconv.Itoa(uid)
+	}
+	return "243"
+}
+
+func testOwnerGID() string {
+	if gid := os.Getgid(); gid >= 0 {
+		return strconv.Itoa(gid)
+	}
+	return "243"
+}
 
 func TestParseEndpoint(t *testing.T) {
 	cases := []struct {
@@ -92,6 +111,149 @@ func TestParseEndpoint(t *testing.T) {
 				if test.respaddr != addr {
 					t.Errorf("test %q failed; expected addr %v, got addr %v", test.desc, test.respaddr, addr)
 				}
+			}
+		})
+	}
+}
+
+func TestParseOwnerID(t *testing.T) {
+	tests := []struct {
+		desc        string
+		field       string
+		value       string
+		expectedID  int
+		expectedErr string
+	}{
+		{
+			desc:       "empty value is unset",
+			field:      paramUID,
+			value:      "",
+			expectedID: unsetOwner,
+		},
+		{
+			desc:       "valid uid",
+			field:      paramUID,
+			value:      "243",
+			expectedID: 243,
+		},
+		{
+			desc:       "zero is valid",
+			field:      paramGID,
+			value:      "0",
+			expectedID: 0,
+		},
+		{
+			desc:        "non-numeric",
+			field:       paramUID,
+			value:       "abc",
+			expectedErr: "invalid uid abc",
+		},
+		{
+			desc:        "negative",
+			field:       paramGID,
+			value:       "-1",
+			expectedErr: "invalid gid -1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			id, err := parseOwnerID(test.field, test.value)
+			if test.expectedErr != "" {
+				if err == nil || err.Error() != test.expectedErr {
+					t.Errorf("expected error %q, got %v", test.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if id != test.expectedID {
+				t.Errorf("expected id %d, got %d", test.expectedID, id)
+			}
+		})
+	}
+}
+
+func TestChownIfOwnerMismatchInjected(t *testing.T) {
+	origFileOwner, origChownPath := fileOwnerFn, chownPathFn
+	t.Cleanup(func() {
+		fileOwnerFn = origFileOwner
+		chownPathFn = origChownPath
+	})
+
+	t.Run("one-sided uid passes -1 gid through to chown", func(t *testing.T) {
+		var gotUID, gotGID int
+		called := false
+		fileOwnerFn = func(string) (int, int, error) { return 0, 0, nil }
+		chownPathFn = func(_ string, uid, gid int) error {
+			called = true
+			gotUID, gotGID = uid, gid
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", 243, unsetOwner); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Fatal("expected chownPath to be called")
+		}
+		if gotUID != 243 || gotGID != unsetOwner {
+			t.Errorf("got %d:%d, want 243:%d", gotUID, gotGID, unsetOwner)
+		}
+	})
+
+	t.Run("matching owner skips chown", func(t *testing.T) {
+		fileOwnerFn = func(string) (int, int, error) { return 243, 243, nil }
+		chownPathFn = func(string, int, int) error {
+			t.Fatal("chownPath should not be called when owner already matches")
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", 243, 243); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both unset is a no-op", func(t *testing.T) {
+		chownPathFn = func(string, int, int) error {
+			t.Fatal("chownPath should not be called when both IDs are unset")
+			return nil
+		}
+		if err := chownIfOwnerMismatch("/tmp/x", unsetOwner, unsetOwner); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestIsDynamicallyProvisioned(t *testing.T) {
+	tests := []struct {
+		desc     string
+		ctx      map[string]string
+		expected bool
+	}{
+		{
+			desc:     "nil context",
+			expected: false,
+		},
+		{
+			desc:     "static PV attributes",
+			ctx:      map[string]string{"server": "nfs", "share": "/", paramUID: "243"},
+			expected: false,
+		},
+		{
+			desc:     "provisioner identity",
+			ctx:      map[string]string{csiProvisionerIdentityKey: "nfs.csi.k8s.io"},
+			expected: true,
+		},
+		{
+			desc:     "pv name alone is not dynamic (static subDir metadata)",
+			ctx:      map[string]string{pvNameKey: "pvc-123", paramUID: "243"},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if got := isDynamicallyProvisioned(test.ctx); got != test.expected {
+				t.Errorf("got %v, want %v", got, test.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-pick of #1252 to `release-4.13`.

Original PR: #1252 (merged as 51f49163).

## Conflict resolution
Only `docs/driver-parameters.md` had conflicts. `release-4.13` does not carry the master-only "When to set \`mountPermissions\`" doc section, so the incoming (PR) side was taken in all three hunks — this adds the `uid`/`gid` StorageClass + `volumeAttributes` rows and the new "When to set \`uid\`/\`gid\`" section without touching any pre-existing release-4.13 doc content. All code changes applied cleanly.