### PR TITLE
fix: address post-merge review of uid/gid feature (#1252)

### DIFF
--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -108,7 +108,7 @@ parameters:
   gid: "243"
 ```
 
-Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers.
+Either parameter may be omitted to leave that ID unchanged. Values must be non-negative decimal integers in the range `0`–`2147483647` (the driver parses uid/gid as signed 32-bit ints; values above `math.MaxInt32` are rejected).
 
 These are StorageClass (or static PV `volumeAttributes`) parameters. The PVC API has no owner fields; CSI only forwards StorageClass parameters. One StorageClass per tenant uid is the supported pattern today.
 

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -236,9 +236,9 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeContext:    paramsWithOwnerDynamic,
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
 				VolumeId:         "vol_1",
-				TargetPath:       targetTest,
-				Readonly:         true},
-			expectedErr: nil,
+				TargetPath:       targetTest},
+			skipOnWindows: true,
+			expectedErr:   nil,
 		},
 		{
 			desc: "[Success] Static PV with pv name metadata still applies uid and gid",

--- a/pkg/nfs/nodeserver_test.go
+++ b/pkg/nfs/nodeserver_test.go
@@ -232,6 +232,17 @@ func TestNodePublishVolume(t *testing.T) {
 		},
 		{
 			desc: "[Success] Valid request with uid and gid on dynamic volume skips node chown",
+			setup: func() {
+				// Force any owner-lookup or chown attempt to fail. This test
+				// only passes if applyUIDGID returns via the dynamic-volume
+				// short-circuit before reaching chownIfOwnerMismatch.
+				fileOwnerFn = func(string) (int, int, error) {
+					return 0, 0, fmt.Errorf("fileOwnerFn should not be called for dynamic volumes")
+				}
+				chownPathFn = func(string, int, int) error {
+					return fmt.Errorf("chownPathFn should not be called for dynamic volumes")
+				}
+			},
 			req: &csi.NodePublishVolumeRequest{
 				VolumeContext:    paramsWithOwnerDynamic,
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -239,6 +250,10 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:       targetTest},
 			skipOnWindows: true,
 			expectedErr:   nil,
+			cleanup: func() {
+				fileOwnerFn = fileOwner
+				chownPathFn = chownPath
+			},
 		},
 		{
 			desc: "[Success] Static PV with pv name metadata still applies uid and gid",


### PR DESCRIPTION
## What this PR does

Post-merge follow-ups on the uid/gid StorageClass parameter feature (#1252), raised during review of the release-4.13 cherry-pick (#1258).

### 1. Document actual uid/gid accepted range

`parseOwnerID` uses `strconv.ParseInt(..., 32)`, so values are bounded at `math.MaxInt32` (`2147483647`). The current docs say "non-negative decimal integers" which implies unbounded acceptance and would send users looking for a bug when a large value gets rejected as `invalid uid`.

### 2. Fix dynamic-volume test that never exercises the dynamic-volume branch

The test case `Valid request with uid and gid on dynamic volume skips node chown` was set to `Readonly: true`. `applyUIDGID` short-circuits on the readonly branch **before** reaching the `isDynamicallyProvisioned` check, so the test passes even if dynamic-volume detection is broken. Making the request writable actually exercises the named behavior.

## Testing

```
go test ./pkg/nfs/ -run TestNodePublishVolume -count=1
ok  	github.com/kubernetes-csi/csi-driver-nfs/pkg/nfs	0.012s
```

## Related

- #1252 — original uid/gid feature
- #1258 — release-4.13 cherry-pick where these gaps were flagged (fixed there in commit 386a3e17)

/kind cleanup
/sig storage
