### PR TITLE
bump github/codeql-action init+analyze from 4.37.8 to 4.37.9

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4


### PR DESCRIPTION
What this PR does / why we need it:

Bumps [github/codeql-action](https://github.com/github/codeql-action) init and analyze from 4.37.8 (`db488dde`) to 4.37.9 (`cdf488f5`) in a single commit.

Both init and analyze must be bumped together — init writes a config file tagged with its own version and analyze refuses to run when the two do not match.

Follows the same pattern as https://github.com/kubernetes-csi/csi-driver-smb/pull/1202.

**Does this PR introduce a user-facing change?**

```
NONE
```
